### PR TITLE
Congratulate and exit when koans are complete

### DIFF
--- a/lib/display.ex
+++ b/lib/display.ex
@@ -56,7 +56,6 @@ defmodule Display do
   def congratulate do
     format_green("\nYou have learned much. You must find your own path now.")
     |> IO.puts
-    exit(:normal)
   end
 
   def clear_screen do

--- a/lib/display.ex
+++ b/lib/display.ex
@@ -23,7 +23,7 @@ defmodule Display do
 
   def show_failure(failure, module, name) do
     IO.puts("Now meditate upon #{format_module(module)}")
-    IO.puts(progress_bar(Tracker.get))
+    IO.puts(progress_bar(Tracker.summarize))
     IO.puts(bar())
     IO.puts(name)
     IO.puts(format_failure(failure))

--- a/lib/display.ex
+++ b/lib/display.ex
@@ -53,6 +53,12 @@ defmodule Display do
     format_error(error) |> IO.puts
   end
 
+  def congratulate do
+    format_green("\nYou have learned much. You must find your own path now.")
+    |> IO.puts
+    exit(:normal)
+  end
+
   def clear_screen do
     if Options.clear_screen? do
       IO.puts(ANSI.clear)
@@ -95,6 +101,10 @@ defmodule Display do
 
   defp format_cyan(str) do
     Enum.join([ANSI.cyan, str, ANSI.reset], "")
+  end
+
+  defp format_green(str) do
+    Enum.join([ANSI.green, str, ANSI.reset], "")
   end
 
   defp format_module(module) do

--- a/lib/meditate.ex
+++ b/lib/meditate.ex
@@ -16,6 +16,8 @@ defmodule Mix.Tasks.Meditate do
     |> Tracker.start
     |> Runner.run
 
+    if Tracker.complete?, do: Display.congratulate
+
     receive do
       {:DOWN, _references, :process, watcher, _reason} -> nil
     end

--- a/lib/meditate.ex
+++ b/lib/meditate.ex
@@ -16,7 +16,10 @@ defmodule Mix.Tasks.Meditate do
     |> Tracker.start
     |> Runner.run
 
-    if Tracker.complete?, do: Display.congratulate
+    if Tracker.complete? do
+      Display.congratulate
+      exit(:normal)
+    end
 
     receive do
       {:DOWN, _references, :process, ^watcher, _reason} -> nil

--- a/lib/meditate.ex
+++ b/lib/meditate.ex
@@ -5,7 +5,8 @@ defmodule Mix.Tasks.Meditate do
   def run(args) do
     Application.ensure_all_started(:elixir_koans)
     Code.compiler_options(ignore_module_conflict: true)
-    Watcher.start
+    {:ok, watcher} = Watcher.start
+    Process.monitor(watcher)
 
     Options.start(args)
 
@@ -15,7 +16,9 @@ defmodule Mix.Tasks.Meditate do
     |> Tracker.start
     |> Runner.run
 
-    :timer.sleep(:infinity)
+    receive do
+      {:DOWN, _references, :process, watcher, _reason} -> nil
+    end
   end
 
   defp ok?(koan) do

--- a/lib/meditate.ex
+++ b/lib/meditate.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Meditate do
     if Tracker.complete?, do: Display.congratulate
 
     receive do
-      {:DOWN, _references, :process, watcher, _reason} -> nil
+      {:DOWN, _references, :process, ^watcher, _reason} -> nil
     end
   end
 

--- a/lib/tracker.ex
+++ b/lib/tracker.ex
@@ -10,7 +10,6 @@ defmodule Tracker do
 
   def get do
     Agent.get(__MODULE__, &(&1))
-    |> summarize
   end
 
   def completed(koan) do
@@ -20,11 +19,12 @@ defmodule Tracker do
   end
 
   def complete? do
-    {total, completed} = Agent.get(__MODULE__, &(&1))
+    {total, completed} = get
     total == Enum.count(completed)
   end
 
-  def summarize({total, completed}) do
+  def summarize, do: get |> summarize
+  defp summarize({total, completed}) do
     %{total: total, current: MapSet.size(completed)}
   end
 end

--- a/lib/tracker.ex
+++ b/lib/tracker.ex
@@ -19,6 +19,11 @@ defmodule Tracker do
     end)
   end
 
+  def complete? do
+    {total, completed} = Agent.get(__MODULE__, &(&1))
+    total == Enum.count(completed)
+  end
+
   def summarize({total, completed}) do
     %{total: total, current: MapSet.size(completed)}
   end

--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -13,7 +13,10 @@ defmodule Watcher do
         e -> Display.show_compile_error(e)
       end
 
-      if Tracker.complete?, do: Display.congratulate
+      if Tracker.complete? do
+        Display.congratulate
+        exit(:normal)
+      end
     end
   end
 end

--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -12,6 +12,8 @@ defmodule Watcher do
       rescue
         e -> Display.show_compile_error(e)
       end
+
+      if Tracker.complete?, do: Display.congratulate
     end
   end
 end

--- a/test/tracker_test.exs
+++ b/test/tracker_test.exs
@@ -5,19 +5,19 @@ defmodule TrackerTest do
 
   test "can start" do
     Tracker.start(@sample_modules)
-    assert Tracker.get == %{total: 2, current: 0}
+    assert Tracker.summarize == %{total: 2, current: 0}
   end
 
   test "can be notified of completed koans" do
     Tracker.start(@sample_modules)
     Tracker.completed(:"Hi there")
-    assert Tracker.get == %{total: 2, current: 1}
+    assert Tracker.summarize == %{total: 2, current: 1}
   end
 
   test "multiple comletions of the same koan count only once" do
     Tracker.start(@sample_modules)
     Tracker.completed(:"Hi there")
     Tracker.completed(:"Hi there")
-    assert Tracker.get == %{total: 2, current: 1}
+    assert Tracker.summarize == %{total: 2, current: 1}
   end
 end


### PR DESCRIPTION
I worked through the entire set of koans and it took me a moment to realize that the last one wasn't stuck. It's because the process never exits (`:timer.sleep(:infinity)`). This restructures the code to print a nice little message when the entire run completes either initially or in the watcher.

I'd like to add tests around all these things, but the tests seem to be a little slim over the supporting code, so I opted to pass for now and test manually instead.

<img width="724" alt="screen shot 2016-04-26 at 5 39 11 pm" src="https://cloud.githubusercontent.com/assets/79619/14836450/d16203fa-0bd5-11e6-8fe2-2b00eadbbb51.png">
