### PR TITLE
Add trailing commas to multi-line lists and maps

### DIFF
--- a/lib/koans/05_maps.ex
+++ b/lib/koans/05_maps.ex
@@ -4,7 +4,7 @@ defmodule Maps do
   @person %{
     name: "Jon",
     last_name: "Snow",
-    age: 27
+    age: 27,
   }
 
   koan "Maps represent structured data, like a person" do

--- a/test/koans/enum_koans_test.exs
+++ b/test/koans/enum_koans_test.exs
@@ -19,7 +19,7 @@ defmodule EnumTests do
       2,
       nil,
       :no_such_element,
-      6
+      6,
     ]
 
     test_all(Enums, answers)

--- a/test/koans/equalities_koan_test.exs
+++ b/test/koans/equalities_koan_test.exs
@@ -10,7 +10,7 @@ defmodule EqualitiesTests do
       2,
       1,
       4,
-      2
+      2,
     ]
 
     test_all(Equalities, answers)

--- a/test/koans/functions_koans_test.exs
+++ b/test/koans/functions_koans_test.exs
@@ -14,7 +14,7 @@ defmodule FunctionsTests do
       6,
       6,
       100,
-      "Full Name"
+      "Full Name",
     ]
 
     test_all(Functions, answers)

--- a/test/koans/maps_koans_test.exs
+++ b/test/koans/maps_koans_test.exs
@@ -14,7 +14,7 @@ defmodule MapsTests do
       [:last_name, :name],
       %{:name => "Jon", :last_name => "Snow"},
       {:ok, "Baratheon"},
-      %{ :name => "Jon", :last_name => "Snow"}
+      %{ :name => "Jon", :last_name => "Snow"},
     ]
 
     test_all(Maps, answers)

--- a/test/koans/patterns_koans_test.exs
+++ b/test/koans/patterns_koans_test.exs
@@ -15,7 +15,7 @@ defmodule PatternsTests do
       [1,2,3],
       {:multiple, ["Meow", "Woof", "Eh?",]},
       "dog",
-      "Max"
+      "Max",
     ]
 
     test_all(PatternMatching, answers)

--- a/test/koans/processes_koans_test.exs
+++ b/test/koans/processes_koans_test.exs
@@ -15,7 +15,7 @@ defmodule ProcessesTests do
       true,
       false,
       {:exited, :normal},
-      {:exited, :normal}
+      {:exited, :normal},
       ]
 
     test_all(Processes, answers)

--- a/test/koans/strings_koan_test.exs
+++ b/test/koans/strings_koan_test.exs
@@ -12,7 +12,7 @@ defmodule StringTests do
       "banana",
       "banana",
       "String",
-      "listen"
+      "listen",
     ]
 
     test_all(Strings, answers)

--- a/test/koans/tasks_koans_test.exs
+++ b/test/koans/tasks_koans_test.exs
@@ -9,7 +9,7 @@ defmodule TasksTests do
       nil,
       false,
       9,
-      [1,4,9,16]
+      [1,4,9,16],
       ]
 
     test_all(Tasks, answers)

--- a/test/koans/tuples_koans_test.exs
+++ b/test/koans/tuples_koans_test.exs
@@ -11,7 +11,7 @@ defmodule TupleTests do
       {:a, :new_thing, "hi"},
       {"Huey", "Dewey", "Louie"},
       {:this, :is, :awesome},
-      [:this, :can, :be, :a, :list]
+      [:this, :can, :be, :a, :list],
     ]
 
     test_all(Tuples, answers)


### PR DESCRIPTION
This is _super_ pedantic, but I noticed an inconsistency in this style in the code, and I happen to prefer it this way 😆 (makes the git history cleaner when appending elements).

Feel free to ignore! 😅💦 