### PR TITLE
Struct koans now calls '|' operator by correct name: 'cons'

### DIFF
--- a/lib/koans/06_structs.ex
+++ b/lib/koans/06_structs.ex
@@ -20,7 +20,7 @@ defmodule Structs do
     assert joe.name == ___
   end
 
-  koan "Update fields with the pipe '|' operator" do
+  koan "Update fields with the cons '|' operator" do
     joe = %Person{name: "Joe", age: 23}
     older = %{joe | age: joe.age + 10}
     assert older.age == ___


### PR DESCRIPTION
Little change to remove some ambiguity in the koans. `|>` is he pipe operator, but `|`, in `erlang/elixir` is the 'cons' operator (short for constructor).