### PR TITLE
Additions to pattern matching koans

### DIFF
--- a/lib/koans/07_pattern_matching.ex
+++ b/lib/koans/07_pattern_matching.ex
@@ -7,7 +7,8 @@ defmodule PatternMatching do
 
   koan "A pattern can change" do
     a = 1
-    assert a = ___
+    a = 2
+    assert (a == 2) == ___
   end
 
   koan "A pattern can also be strict" do

--- a/lib/koans/07_pattern_matching.ex
+++ b/lib/koans/07_pattern_matching.ex
@@ -78,7 +78,7 @@ defmodule PatternMatching do
     assert name.("donkey") == ___
   end
 
-  koan "Errors are shaped differently than sucessful results" do
+  koan "Errors are shaped differently than successful results" do
     dog = %{type: "dog"}
 
     result = case Map.fetch(dog, :type) do

--- a/lib/koans/07_pattern_matching.ex
+++ b/lib/koans/07_pattern_matching.ex
@@ -65,6 +65,18 @@ defmodule PatternMatching do
     assert make_noise(snake) == ___
   end
 
+  koan "And they will only run the code that matches the argument" do
+    name = fn
+      ("duck")  -> "Donald"
+      ("mouse") -> "Mickey"
+      (_other)  -> "I need a name!"
+    end
+
+    assert name.("mouse") == ___
+    assert name.("duck") == ___
+    assert name.("donkey") == ___
+  end
+
   koan "Errors are shaped differently than sucessful results" do
     dog = %{type: "dog"}
 

--- a/test/koans/patterns_koans_test.exs
+++ b/test/koans/patterns_koans_test.exs
@@ -14,6 +14,7 @@ defmodule PatternsTests do
       "Honda",
       [1,2,3],
       {:multiple, ["Meow", "Woof", "Eh?",]},
+      {:multiple, ["Mickey", "Donald", "I need a name!"]},
       "dog",
       "Max",
     ]

--- a/test/koans/patterns_koans_test.exs
+++ b/test/koans/patterns_koans_test.exs
@@ -5,7 +5,7 @@ defmodule PatternsTests do
   test "Pattern Matching" do
     answers = [
       1,
-      2,
+      true,
       1,
       {:multiple, [1, [2,3,4]]},
       [1,2,3,4],
@@ -13,7 +13,7 @@ defmodule PatternsTests do
       "eggs, milk",
       "Honda",
       [1,2,3],
-      {:multiple, ["Meow", "Woof", "Eh?",]},
+      {:multiple, ["Meow", "Woof", "Eh?"]},
       {:multiple, ["Mickey", "Donald", "I need a name!"]},
       "dog",
       "Max",


### PR DESCRIPTION
Hi @felipesere @ukutaht 

I added a new koan for anonymous functions and I also tried to make the koan about the changing pattern a bit clearer. 

I remember when I went through these, I wondered what I was supposed to learn from the "a pattern can change" and "a pattern can also be strict". Because you could make both koans pass with `1`, I didn't understand what was special about it. 

I'm still not sure how to make it more obvious that the strict one cannot be changed though... 

