### PR TITLE
Map.fetch! -> Map.fetch in 06_structs.ex

### DIFF
--- a/lib/koans/06_structs.ex
+++ b/lib/koans/06_structs.ex
@@ -41,6 +41,6 @@ defmodule Structs do
   koan "Struct can be treated like maps" do
     silvia = %Person{age: 22, name: "Silvia"}
 
-    assert Map.fetch!(silvia, :age) == ___
+    assert Map.fetch(silvia, :age) == ___
   end
 end

--- a/test/koans/structs_koans_test.exs
+++ b/test/koans/structs_koans_test.exs
@@ -9,7 +9,7 @@ defmodule StructsTests do
       "Joe",
       33,
       {:multiple, [true, false]},
-      22,
+      {:ok, 22},
     ]
 
     test_all(Structs, answers)


### PR DESCRIPTION
I think is better to continue use safe ```Map.fetch``` until we familiarize users with dangerous function concept.
Not every body comes from ruby background, with knowledge of ```?``` and ```!``` function notations.