### PR TITLE
Error is raised if an answer isn't provided for each koan

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,8 +3,20 @@ ExUnit.start()
 defmodule TestHarness do
   def test_all(module, answers) do
     module.all_koans
+    |> check_answer_count(answers, module)
     |> Enum.zip(answers)
     |> run_all(module)
+  end
+
+  defp check_answer_count(koans, answers, module) do
+    koans_count = length(koans)
+    answer_count = length(answers)
+
+    if length(koans) > length(answers) do
+      raise "Answer missing for #{module}. #{koans_count} koans, but only #{answer_count} answers."
+    else
+      koans
+    end
   end
 
   def run_all(pairs, module) do


### PR DESCRIPTION
Currently, answers are zipped with the list of koans which might allow examples to go untested. This admittedly inelegant solution ensures that you at least provide an answer for each koan. It should provide a good sanity check while TDDing koans.

Honestly I'm not a huge fan of this solution, but it was simple enough to implement and serves to start a conversation about answers. 😃 