### PR TITLE
Assert koan test results

### DIFF
--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -33,8 +33,12 @@ defmodule Koans do
     single_var = Blanks.replace(body, Macro.var(:answer, Koans))
     quote do
       def unquote(name)(answer) do
-        unquote(single_var)
-        :ok
+        try do
+          unquote(single_var)
+          :ok
+        rescue
+          e in _ -> e
+        end
       end
     end
   end
@@ -44,8 +48,12 @@ defmodule Koans do
     quote do
       def unquote(name)({:multiple, answers}) do
         converted = List.to_tuple(answers)
-        unquote(multi_var)
-        :ok
+        try do
+          unquote(multi_var)
+          :ok
+        rescue
+          e in _ -> e
+        end
       end
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -23,7 +23,7 @@ defmodule TestHarness do
   end
 
   defp check_results(results) do
-    Enum.each results, &(assert &1 == :passed)
+    Enum.each(results, &(assert &1 == :passed))
   end
 
   def run_all(pairs, module) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,11 +1,14 @@
 ExUnit.start()
 
 defmodule TestHarness do
+  import ExUnit.Assertions
+
   def test_all(module, answers) do
     module.all_koans
     |> check_answer_count(answers, module)
     |> Enum.zip(answers)
     |> run_all(module)
+    |> check_results
   end
 
   defp check_answer_count(koans, answers, module) do
@@ -17,6 +20,10 @@ defmodule TestHarness do
     else
       koans
     end
+  end
+
+  defp check_results(results) do
+    Enum.each results, &(assert &1 == :passed)
   end
 
   def run_all(pairs, module) do


### PR DESCRIPTION
Currently failing koans cause the parent process to hang while waiting for results. This sends failures back to the parent process and assert that everything passed.