### PR TITLE
Problem with assert_receive in koans

### DIFF
--- a/lib/blanks.ex
+++ b/lib/blanks.ex
@@ -7,9 +7,24 @@ defmodule Blanks do
     |> elem(0)
   end
 
+  defp pre({:assert_receive, _, args} = node, replacements) do
+    {args, replacements} = Macro.prewalk(args, replacements, &pre_pin/2)
+    {put_elem(node, 2, args), replacements}
+  end
   defp pre(:___, [first | remainder]), do: {first, remainder}
   defp pre({:___, _, _}, [first | remainder]), do: {first, remainder}
   defp pre(node, acc), do: {node, acc}
+
+  defp pre_pin(:___, [first | remainder]), do: {pin(first), remainder}
+  defp pre_pin({:___, _, _}, [first | remainder]), do: {pin(first), remainder}
+  defp pre_pin(node, acc), do: {node, acc}
+
+  defp pin(var) when is_tuple(var) do
+    quote do
+      ^unquote(var)
+    end
+  end
+  defp pin(var), do: var
 
   def count(ast) do
     ast

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -13,7 +13,7 @@ defmodule Processes do
 
   koan "You can send messages to any process you want" do
     send self(), "hola!"
-    assert_receive ___
+    assert_receive ^___
   end
 
   koan "A common pattern is to include the sender in the message" do
@@ -24,7 +24,7 @@ defmodule Processes do
                  end)
 
     send pid, {:hello, self()}
-    assert_receive ___
+    assert_receive ^___
   end
 
   koan "Waiting for a message can get boring" do
@@ -35,7 +35,7 @@ defmodule Processes do
                 end
            end)
 
-    assert_receive ___
+    assert_receive ^___
   end
 
   koan "Killing a process will terminate it" do
@@ -64,7 +64,7 @@ defmodule Processes do
     wait()
     Process.exit(pid, :random_reason)
 
-    assert_receive ___
+    assert_receive ^___
   end
 
   koan "Trying to quit normally has no effect" do
@@ -96,7 +96,7 @@ defmodule Processes do
             end
      end)
 
-    assert_receive ___
+    assert_receive ^___
   end
 
   koan "If you monitor your children, you'll be automatically informed for their depature" do
@@ -108,7 +108,7 @@ defmodule Processes do
             end
      end)
 
-    assert_receive ___
+    assert_receive ^___
   end
 
   def wait do

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -13,7 +13,7 @@ defmodule Processes do
 
   koan "You can send messages to any process you want" do
     send self(), "hola!"
-    assert_receive ^___
+    assert_receive ___
   end
 
   koan "A common pattern is to include the sender in the message" do
@@ -24,7 +24,7 @@ defmodule Processes do
                  end)
 
     send pid, {:hello, self()}
-    assert_receive ^___
+    assert_receive ___
   end
 
   koan "Waiting for a message can get boring" do
@@ -35,7 +35,7 @@ defmodule Processes do
                 end
            end)
 
-    assert_receive ^___
+    assert_receive ___
   end
 
   koan "Killing a process will terminate it" do
@@ -64,7 +64,7 @@ defmodule Processes do
     wait()
     Process.exit(pid, :random_reason)
 
-    assert_receive ^___
+    assert_receive ___
   end
 
   koan "Trying to quit normally has no effect" do
@@ -96,7 +96,7 @@ defmodule Processes do
             end
      end)
 
-    assert_receive ^___
+    assert_receive ___
   end
 
   koan "If you monitor your children, you'll be automatically informed for their depature" do
@@ -108,7 +108,7 @@ defmodule Processes do
             end
      end)
 
-    assert_receive ^___
+    assert_receive ___
   end
 
   def wait do

--- a/test/blanks_test.exs
+++ b/test/blanks_test.exs
@@ -24,6 +24,16 @@ defmodule BlanksTest do
     assert Blanks.replace(ast, [true, false]) == quote(do: assert true == false)
   end
 
+  test "pins variables in assert_receive replacement" do
+    ast = quote do: assert_receive ___
+    assert Blanks.replace(ast, Macro.var(:answer, __MODULE__)) == quote(do: assert_receive ^answer)
+  end
+
+  test "does not pin values in assert_receive replacement" do
+    ast = quote do: assert_receive ___
+    assert Blanks.replace(ast, :lolwat) == quote(do: assert_receive :lolwat)
+  end
+
   test "counts simple blanks" do
     ast = quote do: 1 + ___
 

--- a/test/koans/processes_koans_test.exs
+++ b/test/koans/processes_koans_test.exs
@@ -8,7 +8,7 @@ defmodule ProcessesTests do
       :running,
       "hola!",
       :how_are_you?,
-      {:waited_too_long, "I am inpatient"},
+      {:waited_too_long, "I am impatient"},
       false,
       {:multiple, [true, false]},
       {:exited, :random_reason},


### PR DESCRIPTION
I sort of stumbled upon the fact that `assert_receive` isn't working as expected in the koans. It's proven by this typo. I'm not yet sure what the problem is, but I'm assuming it's something to do with the various metaprogramming that's happening amongst these macros... I'll keep working on it, but any input is welcome!