### PR TITLE
Restructure/simplify process koans

### DIFF
--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -69,7 +69,11 @@ defmodule Processes do
                         {:EXIT, _pid, reason} -> send parent, {:exited, reason}
                       end
     end)
-    wait()
+
+    receive do
+      :ready -> true
+    end
+
     Process.exit(pid, :random_reason)
 
     assert_receive ___
@@ -117,11 +121,5 @@ defmodule Processes do
      end)
 
     assert_receive ___
-  end
-
-  def wait do
-    receive do
-      :ready -> true
-    end
   end
 end

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -80,16 +80,16 @@ defmodule Processes do
   end
 
   koan "Trying to quit normally has no effect" do
-    pid = spawn(fn -> receive do
-                      end
-                end)
+    pid = spawn(fn -> receive do end end)
     Process.exit(pid, :normal)
+
     assert Process.alive?(pid) == ___
   end
 
   koan "Exiting normally yourself on the other hand DOES terminate you" do
     pid = spawn(fn -> Process.exit(self, :normal) end)
     :timer.sleep(100)
+
     assert Process.alive?(pid) == ___
   end
 

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -94,27 +94,15 @@ defmodule Processes do
   end
 
   koan "Parent processes can be informed about exiting children, if they trap and link" do
-    parent = self()
-    spawn(fn ->
-            Process.flag(:trap_exit, true)
-            spawn_link(fn -> Process.exit(self(), :normal) end)
-            receive do
-              {:EXIT, _pid ,reason} -> send parent, {:exited, reason}
-            end
-     end)
+    Process.flag(:trap_exit, true)
+    spawn_link(fn -> Process.exit(self, :normal) end)
 
-    assert_receive ___
+    assert_receive {:EXIT, _pid, ___}
   end
 
   koan "If you monitor your children, you'll be automatically informed for their depature" do
-    parent = self()
-    spawn(fn ->
-            spawn_monitor(fn -> Process.exit(self(), :normal) end)
-            receive do
-              {:DOWN, _ref, :process, _pid, reason} -> send parent, {:exited, reason}
-            end
-     end)
+    spawn_monitor(fn -> Process.exit(self(), :normal) end)
 
-    assert_receive ___
+    assert_receive {:DOWN, _ref, :process, _pid, ___}
   end
 end

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -19,7 +19,10 @@ defmodule Processes do
 
   koan "You can send messages to any process you want" do
     send self(), "hola!"
-    assert_receive ___
+
+    receive do
+      msg -> assert msg == ___
+    end
   end
 
   koan "A common pattern is to include the sender in the message" do

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -11,6 +11,12 @@ defmodule Processes do
     assert information[:status] == ___
   end
 
+  koan "New processes are spawned" do
+    pid = spawn(fn -> nil end)
+
+    assert Process.alive?(pid) == ___
+  end
+
   koan "You can send messages to any process you want" do
     send self(), "hola!"
     assert_receive ___

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -1,7 +1,7 @@
 defmodule Processes do
   use Koans
 
-  koan "Tests run in a process" do
+  koan "You are a process" do
     assert Process.alive?(self()) == ___
   end
 
@@ -11,13 +11,13 @@ defmodule Processes do
     assert information[:status] == ___
   end
 
-  koan "New processes are spawned" do
+  koan "New processes are spawned functions" do
     pid = spawn(fn -> nil end)
 
     assert Process.alive?(pid) == ___
   end
 
-  koan "You can send messages to any process you want" do
+  koan "You can send messages to processes" do
     send self(), "hola!"
 
     receive do

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -87,7 +87,7 @@ defmodule Processes do
     assert Process.alive?(pid) == ___
   end
 
-  koan "Exiting yourself on the other hand DOES terminate you" do
+  koan "Exiting normally yourself on the other hand DOES terminate you" do
     pid = spawn(fn -> Process.exit(self, :normal) end)
     :timer.sleep(100)
     assert Process.alive?(pid) == ___

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -88,12 +88,7 @@ defmodule Processes do
   end
 
   koan "Exiting yourself on the other hand DOES terminate you" do
-    pid = spawn(fn -> receive do
-                        :bye -> Process.exit(self(), :normal)
-                      end
-                end)
-
-    send pid, :bye
+    pid = spawn(fn -> Process.exit(self, :normal) end)
     :timer.sleep(100)
     assert Process.alive?(pid) == ___
   end

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -25,7 +25,7 @@ defmodule Processes do
     end
   end
 
-  koan "A common pattern is to include the sender in the message" do
+  koan "A common pattern is to include the sender in the message, so that it can reply" do
     pid = spawn(fn -> receive do
                          {:hello, sender} -> send sender, :how_are_you?
                          _ -> assert false

--- a/lib/koans/10_processes.ex
+++ b/lib/koans/10_processes.ex
@@ -28,7 +28,6 @@ defmodule Processes do
   koan "A common pattern is to include the sender in the message, so that it can reply" do
     pid = spawn(fn -> receive do
                          {:hello, sender} -> send sender, :how_are_you?
-                         _ -> assert false
                       end
                  end)
 

--- a/test/koans/processes_koans_test.exs
+++ b/test/koans/processes_koans_test.exs
@@ -6,6 +6,7 @@ defmodule ProcessesTests do
     answers = [
       true,
       :running,
+      true,
       "hola!",
       :how_are_you?,
       {:waited_too_long, "I am inpatient"},

--- a/test/koans/processes_koans_test.exs
+++ b/test/koans/processes_koans_test.exs
@@ -15,8 +15,8 @@ defmodule ProcessesTests do
       {:exited, :random_reason},
       true,
       false,
-      {:exited, :normal},
-      {:exited, :normal},
+      :normal,
+      :normal,
       ]
 
     test_all(Processes, answers)


### PR DESCRIPTION
While working through the process koans, I found some opportunity to improve the lessons themselves. The changeset is a little noisy, but the story should be relatively clear if read commit-wise.

1. Reword some descriptions
1. Change initial tests to establish baseline: everything's a process, create processes with `spawn`, receive messages with `receive`
1. Get rid of `wait/0` function since it's only used in one place (and might be mistaken for something built-in)
1. Simplify some of the messaging examples by eliminating extra process layers

Also worth mentioning that these examples still suffer from #93, but that should be fixed (or fixable) once we come to a conclusion there.

What do you think?