### PR TITLE
Ensure elixir version is at least 1.2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Koans.Mixfile do
   def project do
     [app: :elixir_koans,
      version: "0.0.1",
-     elixir: "~> 1.2",
+     elixir: ">= 1.2.1",
      elixirc_paths: elixirc_path(Mix.env),
      deps: deps]
   end


### PR DESCRIPTION
The project unfortunately does not compile in elixir version 1.2.0. That major version got released with a bug in ExUnit that fails when assertions are used within macros which we rely heavily on. For users on 1.2.0, this led to a compile error `undefined function answer/0`. This issue is [fixed](https://github.com/elixir-lang/elixir/releases/tag/v1.2.1) in 1.2.1 so that's the minimum we should require.