### PR TITLE
Replace pipeline with composed function in maps koan

### DIFF
--- a/lib/koans/05_maps.ex
+++ b/lib/koans/05_maps.ex
@@ -38,7 +38,7 @@ defmodule Maps do
 
   koan "Can remove pairs by key" do
     without_age = Map.delete(@person, :age)
-    assert Enum.sort(Map.keys(without_age)) == ___
+    assert Map.has_key?(without_age, :age) == ___
   end
 
   koan "Can merge maps" do

--- a/lib/koans/05_maps.ex
+++ b/lib/koans/05_maps.ex
@@ -13,11 +13,6 @@ defmodule Maps do
                         age: 27 }
   end
 
-  koan "A map has keys and values" do
-    assert Enum.sort(Map.keys(@person)) == ___
-    assert Enum.sort(Map.values(@person)) == ___
-  end
-
   koan "Fetching a value returns a tuple with ok when it exists" do
     assert Map.fetch(@person, :age) == ___
   end

--- a/lib/koans/05_maps.ex
+++ b/lib/koans/05_maps.ex
@@ -14,8 +14,8 @@ defmodule Maps do
   end
 
   koan "A map has keys and values" do
-    assert Map.keys(@person) |> Enum.sort == ___
-    assert Map.values(@person) |> Enum.sort == ___
+    assert Enum.sort(Map.keys(@person)) == ___
+    assert Enum.sort(Map.values(@person)) == ___
   end
 
   koan "Fetching a value returns a tuple with ok when it exists" do
@@ -43,7 +43,7 @@ defmodule Maps do
 
   koan "Can remove pairs by key" do
     without_age = Map.delete(@person, :age)
-    assert Map.keys(without_age) |> Enum.sort == ___
+    assert Enum.sort(Map.keys(without_age)) == ___
   end
 
   koan "Can merge maps" do

--- a/test/koans/maps_koans_test.exs
+++ b/test/koans/maps_koans_test.exs
@@ -5,7 +5,6 @@ defmodule MapsTests do
   test "Maps" do
     answers = [
       "Jon",
-      {:multiple, [[:age, :last_name, :name], [27, "Jon", "Snow"]]},
       {:ok, 27},
       :error,
       {:ok, "Kayaking"},

--- a/test/koans/maps_koans_test.exs
+++ b/test/koans/maps_koans_test.exs
@@ -10,7 +10,7 @@ defmodule MapsTests do
       {:ok, "Kayaking"},
       {:ok, 37},
       {:ok, 16},
-      [:last_name, :name],
+      false,
       %{:name => "Jon", :last_name => "Snow"},
       {:ok, "Baratheon"},
       %{ :name => "Jon", :last_name => "Snow"},


### PR DESCRIPTION
At this point, the learner hasn't seen functions, the Enum module, or
the pipe operator, so it feels like a little much to add that here. The
reason it's needed is that the order of keys/1 and values/1 is reverse
of how it's defined. This is due to an implementation detail in Erlang's
maps. We /could/ use this as a learning opportunity rather than sorting
them, but I'm not sure what could be said about that...

Other options include
- get rid of the example
- limit example to single key and value to avoid order problems
- use it as a learning opportunity (what do we learn?)