### PR TITLE
Allow multiple answers in pinned context

### DIFF
--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -43,11 +43,11 @@ defmodule Koans do
     end
   end
   defmacro generate_test_method(name, number_of_args, body) do
-    answer_placeholders = create_vars(number_of_args)
-    multi_var = Blanks.replace(body, answer_placeholders)
+    answer_vars = for id <- 1..number_of_args, do: Macro.var(String.to_atom("answer#{id}"), Koans)
+    multi_var = Blanks.replace(body, answer_vars)
+
     quote do
-      def unquote(name)({:multiple, answers}) do
-        converted = List.to_tuple(answers)
+      def unquote(name)({:multiple, unquote(answer_vars)}) do
         try do
           unquote(multi_var)
           :ok
@@ -66,10 +66,6 @@ defmodule Koans do
   defp blank_line_replacement(line) do
     code = Macro.escape(line)
     quote do: raise ExUnit.AssertionError, expr: unquote(code)
-  end
-
-  defp create_vars(amount) do
-    for id <- 0..amount, do: quote do: elem(converted, unquote(id))
   end
 
   defmacro __using__(_opts) do


### PR DESCRIPTION
Instead of accessing multiple answers via `elem(converted, id)` I've changed the koan macro to just destruct the answers in the test function signature. This way all answers become variables on their own and can be pinned in our special `assert_receive` handling. This PR doesn't include an example of using this but I've confirmed that it works with the `yelling_echo_loop` from #98.

closes #94