### PR TITLE
Add meditate shortdoc to display task in mix list

### DIFF
--- a/lib/meditate.ex
+++ b/lib/meditate.ex
@@ -2,6 +2,8 @@ defmodule Mix.Tasks.Meditate do
   use Mix.Task
   alias Options
 
+  @shortdoc "Start the koans"
+
   def run(args) do
     Application.ensure_all_started(:elixir_koans)
     Code.compiler_options(ignore_module_conflict: true)
@@ -35,4 +37,3 @@ defmodule Mix.Tasks.Meditate do
     end
   end
 end
-


### PR DESCRIPTION
This change makes meditate task visible when user runs `mix help`. 