### PR TITLE
Display inequality, guide learner

### DIFF
--- a/lib/display/colours.ex
+++ b/lib/display/colours.ex
@@ -2,6 +2,7 @@ defmodule Display.Paint do
   def red(str), do: painter().red(str)
   def cyan(str), do: painter().cyan(str)
   def green(str), do: painter().green(str)
+  def yellow(str), do: painter.yellow(str)
 
   defp painter do
     case Mix.env do
@@ -17,6 +18,7 @@ defmodule Display.Colours do
   def red(str), do: colourize(ANSI.red, str)
   def cyan(str), do: colourize(ANSI.cyan, str)
   def green(str), do: colourize(ANSI.green, str)
+  def yellow(str), do: colourize(ANSI.yellow, str)
 
   defp colourize(color, message) do
     Enum.join([color, message, ANSI.reset], "")

--- a/lib/display/colours.ex
+++ b/lib/display/colours.ex
@@ -1,8 +1,6 @@
 defmodule Display.Paint do
   def red(str), do: painter().red(str)
-
   def cyan(str), do: painter().cyan(str)
-
   def green(str), do: painter().green(str)
 
   defp painter do
@@ -17,9 +15,7 @@ defmodule Display.Colours do
   alias IO.ANSI
 
   def red(str), do: colourize(ANSI.red, str)
-
   def cyan(str), do: colourize(ANSI.cyan, str)
-
   def green(str), do: colourize(ANSI.green, str)
 
   defp colourize(color, message) do

--- a/lib/display/failure.ex
+++ b/lib/display/failure.ex
@@ -9,16 +9,28 @@ defmodule Display.Failure do
     #{Paint.red(message)}
     """
   end
-  def format_failure(%{error: %ExUnit.AssertionError{expr: expr}, file: file, line: line}) do
+  def format_failure(%{error: %ExUnit.AssertionError{expr: expr} = error, file: file, line: line}) do
     """
     #{Paint.cyan("Assertion failed in #{file}:#{line}")}
     #{Paint.red(Macro.to_string(expr))}
     """
+    |> format_inequality(error)
   end
   def format_failure(%{error: error, file: file, line: line}) do
     """
     #{Paint.cyan("Error in #{file}:#{line}")}
     #{format_error(error)}
+    """
+  end
+
+  defp format_inequality(message, %{left: @no_value, right: @no_value}) do
+    message
+  end
+  defp format_inequality(message, %{left: left, right: right}) do
+    """
+    #{message}
+    left:  #{left |> inspect |> Paint.yellow}
+    right: #{right |> inspect |> Paint.yellow}
     """
   end
 

--- a/lib/display/failure.ex
+++ b/lib/display/failure.ex
@@ -10,19 +10,15 @@ defmodule Display.Failure do
     """
   end
   def format_failure(%{error: %ExUnit.AssertionError{expr: expr}, file: file, line: line}) do
-    format_assertion_error(expr, file, line)
+    """
+    #{Paint.cyan("Assertion failed in #{file}:#{line}")}
+    #{Paint.red(Macro.to_string(expr))}
+    """
   end
   def format_failure(%{error: error, file: file, line: line}) do
     """
     #{Paint.cyan("Error in #{file}:#{line}")}
     #{format_error(error)}
-    """
-  end
-
-  defp format_assertion_error(error, file, line) do
-    """
-    #{Paint.cyan("Assertion failed in #{file}:#{line}")}
-    #{Paint.red(Macro.to_string(error))}
     """
   end
 


### PR DESCRIPTION
Show left and right hand values when equality fails
For assertions that contain function calls, displaying just the
expression is not helpful. For e.g.

    Assertion failed
    String.upcase("foo") == "Foo"

The learner is given no extra information to help them learn. Sure they
might consult the documentation (and should!), but perhaps a better
experience would be for us to inform the learner about the values it
encountered.

    Assertion failed
    String.upcase("foo") == "Foo"
    left:  "FOO"
    right: "Foo"

Learner: 💡 ah hah! it upcases the whole string! 💫

One might argue that this reveals too much information/makes it too easier. This has not been my experience in pairing with learners. What do you think?