### PR TITLE
Only run elixir files

### DIFF
--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -13,16 +13,18 @@ defmodule Watcher do
   end
 
   defp reload(file) do
-    try do
-      file
-      |> normalize
-      |> Code.load_file
-      |> Enum.map(&(elem(&1, 0)))
-      |> Enum.find(&Runner.koan?/1)
-      |> Runner.modules_to_run
-      |> Runner.run
-    rescue
-      e -> Display.show_compile_error(e)
+    if Path.extname(file) == ".ex" do
+      try do
+        file
+        |> normalize
+        |> Code.load_file
+        |> Enum.map(&(elem(&1, 0)))
+        |> Enum.find(&Runner.koan?/1)
+        |> Runner.modules_to_run
+        |> Runner.run
+      rescue
+        e -> Display.show_compile_error(e)
+      end
     end
   end
 


### PR DESCRIPTION
Ignore, for example, temporary swap files created by an editor.

Otherwise you see errors like this:

```
** (Code.LoadError) could not load /home/bc/elixir-koans/lib/koans/.02_strings.ex.swx
    (elixir) lib/code.ex:657: Code.find_file/2
    (elixir) lib/code.ex:319: Code.load_file/2

** (UnicodeConversionError) invalid encoding starting at <<222, 123, 87, 62, 37, 42, 0, 122, 46, 0, 0, 98, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...>>
    (elixir) lib/string.ex:1746: String.to_charlist/1
    (elixir) src/elixir_compiler.erl:45: :elixir_compiler.file/2

** (Code.LoadError) could not load /home/bc/elixir-koans/lib/koans/.02_strings.ex.swp
    (elixir) lib/code.ex:657: Code.find_file/2
    (elixir) lib/code.ex:319: Code.load_file/2
```