### PR TITLE
A few tweaks to Blanks

### DIFF
--- a/lib/blanks.ex
+++ b/lib/blanks.ex
@@ -11,11 +11,9 @@ defmodule Blanks do
     {args, replacements} = Macro.prewalk(args, replacements, &pre_pin/2)
     {put_elem(node, 2, args), replacements}
   end
-  defp pre(:___, [first | remainder]), do: {first, remainder}
   defp pre({:___, _, _}, [first | remainder]), do: {first, remainder}
   defp pre(node, acc), do: {node, acc}
 
-  defp pre_pin(:___, [first | remainder]), do: {pin(first), remainder}
   defp pre_pin({:___, _, _}, [first | remainder]), do: {pin(first), remainder}
   defp pre_pin(node, acc), do: {node, acc}
 
@@ -32,7 +30,6 @@ defmodule Blanks do
     |> elem(1)
   end
 
-  defp count(:___ = node, acc), do: {node, acc+1}
   defp count({:___, _, _} = node, acc), do: {node, acc+1}
   defp count(node, acc), do: {node, acc}
 

--- a/lib/blanks.ex
+++ b/lib/blanks.ex
@@ -1,7 +1,7 @@
 defmodule Blanks do
-  def replace(ast, replacement) when not is_list(replacement), do: replace(ast, [replacement])
   def replace([do: ast], replacements), do: [do: replace(ast, replacements)]
   def replace(ast, replacements) do
+    replacements = List.wrap(replacements)
     ast
     |> Macro.prewalk(replacements, &pre/2)
     |> elem(0)

--- a/lib/blanks.ex
+++ b/lib/blanks.ex
@@ -1,5 +1,4 @@
 defmodule Blanks do
-  def replace([do: ast], replacements), do: [do: replace(ast, replacements)]
   def replace(ast, replacements) do
     replacements = List.wrap(replacements)
     ast
@@ -33,7 +32,6 @@ defmodule Blanks do
   defp count({:___, _, _} = node, acc), do: {node, acc+1}
   defp count(node, acc), do: {node, acc}
 
-  def replace_line([do: ast], replacement_fn), do: [do: replace_line(ast, replacement_fn)]
   def replace_line({:__block__, meta, lines}, replacement_fn) do
     replaced_lines = Enum.map(lines, fn(line) ->
       replace_line(line, replacement_fn)


### PR DESCRIPTION
Just a few small clean ups. The only thing I'm not completely confident with is the removal of the `:do` function heads. I suppose this works because the Macro.prewalk used further down the call stack can account for it?