### PR TITLE
Bump elixir version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: elixir
-elixir:
-  - 1.2.2
-otp_release:
-  - 18.2.1
+matrix:
+  include:
+    - elixir: 1.2.2
+      otp_release: 18.2.1
+    - elixir: 1.3.4
+      otp_release: 19.1

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Koans.Mixfile do
   def project do
     [app: :elixir_koans,
      version: "0.0.1",
-     elixir: ">= 1.2.1",
+     elixir: ">= 1.2.1 and < 1.4.0",
      elixirc_paths: elixirc_path(Mix.env),
      deps: deps]
   end


### PR DESCRIPTION
This will require the version to be at least 1.3 and less than 1.4. I'm assuming that most people using this aren't bound to a specific, older version and will be able to update. We'll have to revisit this when 1.4 comes out, but at that point we'd probably want to update the travis build anyway.