### PR TITLE
Format match failures

### DIFF
--- a/lib/display/colours.ex
+++ b/lib/display/colours.ex
@@ -27,8 +27,6 @@ end
 
 defmodule Display.Uncoloured do
   def red(str), do: str
-
   def cyan(str), do: str
-
   def green(str), do: str
 end

--- a/lib/display/colours.ex
+++ b/lib/display/colours.ex
@@ -29,4 +29,5 @@ defmodule Display.Uncoloured do
   def red(str), do: str
   def cyan(str), do: str
   def green(str), do: str
+  def yellow(str), do: str
 end

--- a/lib/display/failure.ex
+++ b/lib/display/failure.ex
@@ -26,6 +26,12 @@ defmodule Display.Failure do
   defp format_inequality(message, %{left: @no_value, right: @no_value}) do
     message
   end
+  defp format_inequality(message, %{left: @no_value, right: match_value}) do
+    """
+    #{message}
+    value does not match: #{match_value |> inspect |> Paint.yellow}
+    """
+  end
   defp format_inequality(message, %{left: left, right: right}) do
     """
     #{message}

--- a/test/display/failure_test.exs
+++ b/test/display/failure_test.exs
@@ -5,13 +5,13 @@ defmodule FailureTests do
   test "assertion failure with proper expression" do
     error = error(%ExUnit.AssertionError{expr: "hi"})
 
-   assert Failure.format_failure(error) == "Assertion failed in some_file.ex:42\n\"hi\"\n"
+    assert Failure.format_failure(error) == "Assertion failed in some_file.ex:42\n\"hi\"\n"
   end
 
   test "assertion failure with message" do
     error = error(%ExUnit.AssertionError{expr: :ex_unit_no_meaningful_value, message: "hola"})
 
-   assert Failure.format_failure(error) == "Assertion failed in some_file.ex:42\nhola\n"
+    assert Failure.format_failure(error) == "Assertion failed in some_file.ex:42\nhola\n"
   end
 
   defp error(error) do

--- a/test/display/failure_test.exs
+++ b/test/display/failure_test.exs
@@ -14,6 +14,17 @@ defmodule FailureTests do
     assert Failure.format_failure(error) == "Assertion failed in some_file.ex:42\nhola\n"
   end
 
+  test "equality failure" do
+    error = error(%ExUnit.AssertionError{expr: quote(do: :lol == :wat), left: :lol, right: :wat})
+
+    assert Failure.format_failure(error) == """
+                                            Assertion failed in some_file.ex:42
+                                            :lol == :wat
+
+                                            left:  :lol
+                                            right: :wat
+                                            """
+  end
   defp error(error) do
     %{
       error: error,

--- a/test/display/failure_test.exs
+++ b/test/display/failure_test.exs
@@ -25,6 +25,18 @@ defmodule FailureTests do
                                             right: :wat
                                             """
   end
+
+  test "match failure" do
+    error = error(%ExUnit.AssertionError{expr: quote(do: match?(:lol,:wat)), right: :wat})
+
+    assert Failure.format_failure(error) == """
+                                            Assertion failed in some_file.ex:42
+                                            match?(:lol, :wat)
+
+                                            value does not match: :wat
+                                            """
+  end
+
   defp error(error) do
     %{
       error: error,


### PR DESCRIPTION
This formats match failures to provide clearer learner feedback. ExUnit has a [special case](https://github.com/elixir-lang/elixir/blob/3b499ffb87269d3fa7c874e1deb55b3a30435027/lib/ex_unit/lib/ex_unit/assertions.ex#L145-L158) for `match?`. Also, I went ahead and added tests around inequality failures and it caught a missing interface on the test painter! 💫 

![screen shot 2016-12-23 at 8 10 37 am](https://cloud.githubusercontent.com/assets/79619/21455982/3ac21764-c8ea-11e6-865c-61e00769d91a.png)

[Closes #144]