### PR TITLE
Test for single arity failures

### DIFF
--- a/test/display/failure_test.exs
+++ b/test/display/failure_test.exs
@@ -37,7 +37,7 @@ defmodule FailureTests do
                                             """
   end
 
-  test "single arity failure" do
+  test "only offending lines are displayed for errors" do
     [koan] = SingleArity.all_koans
     error  = apply(SingleArity, koan, []) |> error()
 

--- a/test/display/failure_test.exs
+++ b/test/display/failure_test.exs
@@ -37,6 +37,15 @@ defmodule FailureTests do
                                             """
   end
 
+  test "single arity failure" do
+    [koan] = SingleArity.all_koans
+    error  = apply(SingleArity, koan, []) |> error()
+
+    assert Failure.format_failure(error) == """
+    Assertion failed in some_file.ex:42\nmatch?(:foo, ___)
+    """
+  end
+
   defp error(error) do
     %{
       error: error,

--- a/test/support/single_arity_koan.ex
+++ b/test/support/single_arity_koan.ex
@@ -1,0 +1,11 @@
+defmodule SingleArity do
+  use Koans
+
+  @intro """
+  A koan with single arity testing
+  """
+
+  koan "Only one" do
+    assert match?(:foo, ___)
+  end
+end


### PR DESCRIPTION
This is the best that could come up with to deal with #153 

It does fail when the `do: ` is missing, but it is not immediately obvious...

@iamvery what do you think? Something to pivot on?