### PR TITLE
Normalize the file before calling reload.

### DIFF
--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -3,7 +3,7 @@ defmodule Watcher do
 
   def callback(file, events)  do
     if Enum.member?(events, :modified) do
-      reload(file)
+      file |> normalize |> reload
 
       if Tracker.complete? do
         Display.congratulate
@@ -16,7 +16,6 @@ defmodule Watcher do
     if Path.extname(file) == ".ex" do
       try do
         file
-        |> normalize
         |> Code.load_file
         |> Enum.map(&(elem(&1, 0)))
         |> Enum.find(&Runner.koan?/1)


### PR DESCRIPTION
Fixing: https://github.com/elixirkoans/elixir-koans/issues/138

By normalizing first we remove the IntelliJ specific suffix if it is
present which allows the ".ex" extension to correctly match IntelliJ
edited files.