### PR TITLE
Fix Elixir 1 4 warnings

### DIFF
--- a/lib/display/colours.ex
+++ b/lib/display/colours.ex
@@ -2,7 +2,7 @@ defmodule Display.Paint do
   def red(str), do: painter().red(str)
   def cyan(str), do: painter().cyan(str)
   def green(str), do: painter().green(str)
-  def yellow(str), do: painter.yellow(str)
+  def yellow(str), do: painter().yellow(str)
 
   defp painter do
     case Mix.env do

--- a/lib/koans/15_processes.ex
+++ b/lib/koans/15_processes.ex
@@ -4,17 +4,17 @@ defmodule Processes do
   @intro "Processes"
 
   koan "You are a process" do
-    assert Process.alive?(self) == ___
+    assert Process.alive?(self()) == ___
   end
 
   koan "You can ask a process to introduce itself" do
-    information = Process.info(self)
+    information = Process.info(self())
 
     assert information[:status] == ___
   end
 
   koan "Processes are referenced by their process ID (pid)" do
-    assert is_pid(self) == ___
+    assert is_pid(self()) == ___
   end
 
   koan "New processes are spawned functions" do
@@ -24,7 +24,7 @@ defmodule Processes do
   end
 
   koan "Processes can send and receive messages" do
-    send self, "hola!"
+    send self(), "hola!"
 
     receive do
       msg -> assert msg == ___
@@ -32,8 +32,8 @@ defmodule Processes do
   end
 
   koan "Received messages are queued, first in first out" do
-    send self, "hola!"
-    send self, "como se llama?"
+    send self(), "hola!"
+    send self(), "como se llama?"
 
     assert_receive ___
     assert_receive ___
@@ -48,7 +48,7 @@ defmodule Processes do
 
     pid = spawn(greeter)
 
-    send pid, {:hello, self}
+    send pid, {:hello, self()}
     assert_receive ___
   end
 
@@ -56,17 +56,17 @@ defmodule Processes do
     receive do
       {caller, value} ->
         send caller, String.upcase(value)
-        yelling_echo_loop
+        yelling_echo_loop()
     end
   end
 
   koan "Use tail recursion to receive multiple messages" do
     pid = spawn_link(&yelling_echo_loop/0)
 
-    send pid, {self, "o"}
+    send pid, {self(), "o"}
     assert_receive ___
 
-    send pid, {self, "hai"}
+    send pid, {self(), "hai"}
     assert_receive ___
   end
 
@@ -86,16 +86,16 @@ defmodule Processes do
       state(initial_state)
     end)
 
-    send pid, {self, :get}
+    send pid, {self(), :get}
     assert_receive ___
 
-    send pid, {self, :set, "bar"}
-    send pid, {self, :get}
+    send pid, {self(), :set, "bar"}
+    send pid, {self(), :get}
     assert_receive ___
   end
 
   koan "Waiting for a message can get boring" do
-    parent = self
+    parent = self()
     spawn(fn -> receive do
                 after
                   5 -> send parent, {:waited_too_long, "I am impatient"}
@@ -106,7 +106,7 @@ defmodule Processes do
   end
 
   koan "Trapping will allow you to react to someone terminating the process" do
-    parent = self
+    parent = self()
     pid = spawn(fn ->
                       Process.flag(:trap_exit, true)
                       send parent, :ready
@@ -126,13 +126,13 @@ defmodule Processes do
 
   koan "Parent processes can trap exits for children they are linked to" do
     Process.flag(:trap_exit, true)
-    spawn_link(fn -> Process.exit(self, :normal) end)
+    spawn_link(fn -> Process.exit(self(), :normal) end)
 
     assert_receive {:EXIT, _pid, ___}
   end
 
   koan "If you monitor your children, you'll be automatically informed for their depature" do
-    spawn_monitor(fn -> Process.exit(self, :normal) end)
+    spawn_monitor(fn -> Process.exit(self(), :normal) end)
 
     assert_receive {:DOWN, _ref, :process, _pid, ___}
   end

--- a/lib/tracker.ex
+++ b/lib/tracker.ex
@@ -20,15 +20,15 @@ defmodule Tracker do
   end
 
   def visited do
-    summarize[:visited_modules]
+    summarize()[:visited_modules]
   end
 
   def complete? do
-    %{total: total, current: completed} = summarize
+    %{total: total, current: completed} = summarize()
     total == completed
   end
 
-  def summarize, do: get |> summarize
+  def summarize, do: get() |> summarize()
   defp summarize(%{total: total,
                   koans: completed,
                   visited_modules: modules}) do

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Koans.Mixfile do
      version: "0.0.1",
      elixir: ">= 1.2.1 and <= 1.4.0",
      elixirc_paths: elixirc_path(Mix.env),
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Koans.Mixfile do
   end
 
   defp deps do
-    [{:exfswatch, "~> 0.1.1"}]
+    [{:exfswatch, "~> 0.3"}]
   end
 
   defp elixirc_path(:test), do: ["lib/", "test/support"]

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"exfswatch": {:hex, :exfswatch, "0.1.1", "7ccf6fc9b443d04dada3e50b21f910b4d0e4546ce7772dc6d4181fb929ea186f", [:mix], [{:fs, "~> 0.9", [hex: :fs, optional: false]}]},
-  "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []}}
+%{"exfswatch": {:hex, :exfswatch, "0.3.0", "4b07f871460c931e66a4a6af00510dfab9a9c8db3e519f21152a88bec4797a46", [:mix], [{:fs, "~> 2.12", [hex: :fs, optional: false]}]},
+  "fs": {:hex, :fs, "2.12.0", "ad631efacc9a5683c8eaa1b274e24fa64a1b8eb30747e9595b93bec7e492e25e", [:rebar3], []}}


### PR DESCRIPTION
This should fix all the warnings from Elixir 1.4 like:

> warning: variable "..." does not exist and is being expanded to "...()", please use parentheses to remove the ambiguity or change the variable name

h/t @dylan-chong #157 