### PR TITLE
Just 'nil' might have lived long enough, 'receive' definitly does.

### DIFF
--- a/lib/koans/15_processes.ex
+++ b/lib/koans/15_processes.ex
@@ -18,7 +18,9 @@ defmodule Processes do
   end
 
   koan "New processes are spawned functions" do
-    value = spawn(fn -> nil end)
+    value = spawn(fn -> receive do
+                      end
+                end)
 
     assert is_pid(value) == ___
   end


### PR DESCRIPTION
Should clarify #166 

`receive do; end` blocks the spawned thread so it's guaranteed to be alive when we assert.