### PR TITLE
Fetching values of repeated key in keywordlist

### DIFF
--- a/lib/koans/07_keyword_lists.ex
+++ b/lib/koans/07_keyword_lists.ex
@@ -15,11 +15,11 @@ defmodule KeywordLists do
     assert kw_list[:foo] == ___
   end
 
-  koan "You could access a second key by removing the first" do
-    kw_list = [foo: "bar", foo: "baz"]
-    [_|kw_list] = kw_list
+  koan "You could access the values of repeating key" do
+    kw_list = [foo: "bar", foo1: "bar1", foo: "baz"]
+    values = Keyword.get_values(kw_list, :foo)
 
-    assert kw_list[:foo] == ___
+    assert List.last(values) == ___
   end
 
   koan "Keyword lists are just special syntax for lists of two-element tuples" do

--- a/lib/koans/12_pattern_matching.ex
+++ b/lib/koans/12_pattern_matching.ex
@@ -45,6 +45,12 @@ defmodule PatternMatching do
     end
   end
 
+  koan "So does the keyword lists" do
+    kw_list = [type: "car", year: 2016, make: "Honda"]
+    [_type | [_year | [tuple]]] = kw_list
+    assert tuple == {___, ___}
+  end
+
   koan "The pattern can make assertions about what it expects" do
     assert match?([1, _second, _third], ___)
   end

--- a/test/koans/patterns_koans_test.exs
+++ b/test/koans/patterns_koans_test.exs
@@ -11,6 +11,7 @@ defmodule PatternsTests do
       "eggs, milk",
       "Honda",
       MatchError,
+      {:multiple, [:make, "Honda"]},
       [1,2,3],
       {:multiple, ["Meow", "Woof", "Eh?"]},
       {:multiple, ["Mickey", "Donald", "I need a name!"]},


### PR DESCRIPTION
Koan 7.3 is not clear. Updated to make it generic and use List module instead of pattern matching (which is not yet introduced to the learner)