### PR TITLE
Replaced spawn_link call with a simple spawn

### DIFF
--- a/lib/koans/15_processes.ex
+++ b/lib/koans/15_processes.ex
@@ -87,7 +87,7 @@ defmodule Processes do
   end
 
   koan "Use tail recursion to receive multiple messages" do
-    pid = spawn_link(&yelling_echo_loop/0)
+    pid = spawn(&yelling_echo_loop/0)
 
     send pid, {self(), "o"}
     assert_receive ___


### PR DESCRIPTION
spawn_link call seems not needed here.
I tried it (Elixir 1.5.1) and the test seems to fails and succeeds exactly in the same way.

Is there another reason that I'm ignoring?