### PR TITLE
Use more succinct syntax for mapping with String.capitalize

### DIFF
--- a/lib/koans/13_functions.ex
+++ b/lib/koans/13_functions.ex
@@ -92,7 +92,7 @@ defmodule Functions do
   koan "The result of a function can be piped into another function as its first argument" do
     result = "full-name"
             |> String.split("-")
-            |> Enum.map(&(String.capitalize(&1)))
+            |> Enum.map(&String.capitalize/1)
             |> Enum.join(" ")
 
     assert result == ___


### PR DESCRIPTION
It's more idiomatic and that syntax was introduced two koans earlier, so it should be OK to use it.