### PR TITLE
introduce MapSet.size/1 earlier

### DIFF
--- a/lib/koans/09_map_sets.ex
+++ b/lib/koans/09_map_sets.ex
@@ -9,6 +9,10 @@ defmodule MapSets do
     assert Enum.fetch(@set, 0) == {:ok, ___}
   end
 
+  koan "How large is my map set?" do
+    assert MapSet.size(@set) == ___
+  end
+
   koan "However, I do not allow duplication" do
     new_set = MapSet.new([1, 1, 2, 3, 3, 3])
 
@@ -54,10 +58,6 @@ defmodule MapSets do
     modified_set = MapSet.delete(@set, 1)
 
     assert MapSet.member?(modified_set, 1) == ___
-  end
-
-  koan "How large is my map set?" do
-    assert MapSet.size(@set) == ___
   end
 
   koan "Are these maps twins?" do

--- a/lib/koans/09_map_sets.ex
+++ b/lib/koans/09_map_sets.ex
@@ -9,10 +9,6 @@ defmodule MapSets do
     assert Enum.fetch(@set, 0) == {:ok, ___}
   end
 
-  koan "How large is my map set?" do
-    assert MapSet.size(@set) == ___
-  end
-
   koan "However, I do not allow duplication" do
     new_set = MapSet.new([1, 1, 2, 3, 3, 3])
 

--- a/test/koans/map_sets_koans_test.exs
+++ b/test/koans/map_sets_koans_test.exs
@@ -5,7 +5,6 @@ defmodule MapSetsTest do
   test "MapSets" do
     answers = [
       1,
-      5,
       3,
       {:multiple, [false, true]},
       true,

--- a/test/koans/map_sets_koans_test.exs
+++ b/test/koans/map_sets_koans_test.exs
@@ -5,13 +5,13 @@ defmodule MapSetsTest do
   test "MapSets" do
     answers = [
       1,
+      5,
       3,
       {:multiple, [false, true]},
       true,
       {:multiple, [true, false]},
       true,
       false,
-      5,
       false,
       true,
       7,


### PR DESCRIPTION
specifically, before it is used to show sets do not have duplicates

Edit: Instead, remove the later `MapSet.size/1` koan as the function is sufficiently introduced by `koan "However, I do not allow duplication"`.