### PR TITLE
Replace deprecated call to Code.load_file/1

### DIFF
--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -24,7 +24,7 @@ defmodule Watcher do
     if Path.extname(file) == ".ex" do
       try do
         file
-        |> Code.load_file()
+        |> Code.compile_file()
         |> Enum.map(&elem(&1, 0))
         |> Enum.find(&Runner.koan?/1)
         |> Runner.modules_to_run()


### PR DESCRIPTION
This function was replaced by Code.compile_file/1 and is deprecated with
planned removal in 1.9.

See: https://github.com/elixir-lang/elixir/pull/7201

Noticed this when looking into #228