### PR TITLE
Mount only the koans directory, not the whole project

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,2 +1,4 @@
-#!/bin/sh
-docker build -t elixir-koans . && docker run --rm -v `pwd`:/elixir-koans -ti elixir-koans
+#!/bin/sh -e
+
+docker build -t elixir-koans .
+docker run --rm -v `pwd`/lib/koans:/elixir-koans/lib/koans -ti elixir-koans


### PR DESCRIPTION
Mounting the whole project as part of the docker run command means that the mix deps performed in the Dockerfile has the installation wiped out by mounting the local project directory (which does not include the deps directory since that was only inside the container when mix deps was performed during the docker build).

The error shows up as dependencies not being available when the container is actually run.

```
♥ $ ./docker.sh
Sending build context to Docker daemon  639.5kB
Step 1/7 : FROM elixir:1.5
 ---> 2d2fdf265444
Step 2/7 : RUN apt-get update && apt-get install -y inotify-tools
 ---> Using cache
 ---> f05c90e095eb
Step 3/7 : WORKDIR /elixir-koans
 ---> Using cache
 ---> e9a5c4bf803c
Step 4/7 : ADD . /elixir-koans/
 ---> 708161a5a47c
Step 5/7 : RUN mix local.hex --force
 ---> Running in 88a7d1afacec
* creating /root/.mix/archives/hex-0.20.0
Removing intermediate container 88a7d1afacec
 ---> ea0c41f45ad3
Step 6/7 : RUN mix deps.get
 ---> Running in d62f2eef2b64
Resolving Hex dependencies...
Dependency resolution completed:
Unchanged:
  file_system 0.2.2
* Getting file_system (Hex package)
Removing intermediate container d62f2eef2b64
 ---> eb6e57c27afe
Step 7/7 : CMD mix meditate
 ---> Running in a2ad8032fc6a
Removing intermediate container a2ad8032fc6a
 ---> de5276c6cc3a
Successfully built de5276c6cc3a
Successfully tagged elixir-koans:latest
Unchecked dependencies for environment dev:
* file_system (Hex package)
  the dependency is not available, run "mix deps.get"
** (Mix) Can't continue due to errors on dependencies
```

This patch changes to only mounting the koans directory.

Please forgive me if I am missing something needed later but I'm brand new to elixir and am attempting to use the koans to learn.

A resulting run from a completely clean installation:
```
♥ $ ./docker.sh
Sending build context to Docker daemon  646.1kB
Step 1/7 : FROM elixir:1.5
 ---> 2d2fdf265444
Step 2/7 : RUN apt-get update && apt-get install -y inotify-tools
 ---> Using cache
 ---> f05c90e095eb
Step 3/7 : WORKDIR /elixir-koans
 ---> Using cache
 ---> e9a5c4bf803c
Step 4/7 : ADD . /elixir-koans/
 ---> 794ecfd0b8b0
Step 5/7 : RUN mix local.hex --force
 ---> Running in 215da725f1ac
* creating /root/.mix/archives/hex-0.20.0
Removing intermediate container 215da725f1ac
 ---> 7799119f8d25
Step 6/7 : RUN mix deps.get
 ---> Running in 2e35779c6779
Resolving Hex dependencies...
Dependency resolution completed:
Unchanged:
  file_system 0.2.2
* Getting file_system (Hex package)
Removing intermediate container 2e35779c6779
 ---> 41c7f8e944c5
Step 7/7 : CMD mix meditate
 ---> Running in 917b539f04aa
Removing intermediate container 917b539f04aa
 ---> bbc951476ceb
Successfully built bbc951476ceb
Successfully tagged elixir-koans:latest
==> file_system
Compiling 6 files (.ex)
Generated file_system app
==> elixir_koans
Compiling 34 files (.ex)
warning: no clause will ever match
  lib/koans/12_pattern_matching.ex:44

warning: the result of the expression is ignored (suppress the warning by assigning the expression to the _ variable)
  lib/koans/10_structs.ex:27

warning: function Code.compile_file/1 is undefined or private. Did you mean one of:

      * compile_quoted/1
      * compile_quoted/2
      * compile_string/1
      * compile_string/2
      * compiler_options/0

  lib/watcher.ex:43

Generated elixir_koans app


Welcome to the Elixir koans.
Let these be your first humble steps towards learning a new language.

The path laid in front of you is one of many.


Now meditate upon Equalities
|                              | 0 of 210
----------------------------------------
We shall contemplate truth by testing reality, via equality
Assertion failed in lib/koans/01_equalities.ex:12
true == ___

```