### PR TITLE
Update handling of --no-clear-screen switch

### DIFF
--- a/lib/meditate.ex
+++ b/lib/meditate.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Meditate do
     Application.ensure_all_started(:elixir_koans)
     Code.compiler_options(ignore_module_conflict: true)
 
-    {parsed, _, _} = OptionParser.parse(args)
+    {parsed, _, _} = OptionParser.parse(args, strict: [clear_screen: :boolean])
 
     modules =
       parsed
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Meditate do
   end
 
   defp set_clear_screen(parsed) do
-    if Keyword.has_key?(parsed, :no_clear_screen) do
+    unless Keyword.get(parsed, :clear_screen, true) do
       Display.disable_clear()
     end
   end


### PR DESCRIPTION
- pass `strict:` option to [`OptionParser.parse/2`](https://hexdocs.pm/elixir/OptionParser.html#parse/2)
- use [negation](https://hexdocs.pm/elixir/OptionParser.html#parse/2-negation-switches)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elixirkoans/elixir-koans/240)
<!-- Reviewable:end -->
