### PR TITLE
Remove stacktrace warning

### DIFF
--- a/lib/display/failure.ex
+++ b/lib/display/failure.ex
@@ -49,8 +49,7 @@ defmodule Display.Failure do
   end
 
   defp format_error(error) do
-    trace = :erlang.get_stacktrace() |> Enum.take(2)
-    Paint.red(Exception.format(:error, error, trace))
+    Paint.red(Exception.format(:error, error, []))
   end
 
   def show_compile_error(error) do

--- a/lib/display/failure.ex
+++ b/lib/display/failure.ex
@@ -49,7 +49,7 @@ defmodule Display.Failure do
   end
 
   defp format_error(error) do
-    trace = System.stacktrace() |> Enum.take(2)
+    trace = :erlang.get_stacktrace() |> Enum.take(2)
     Paint.red(Exception.format(:error, error, trace))
   end
 

--- a/lib/execute.ex
+++ b/lib/execute.ex
@@ -40,7 +40,7 @@ defmodule Execute do
 
   defp expand({:error, stacktrace, exception}, module) do
     {file, line} =
-      stacktrace
+      :erlang.get_stacktrace()
       |> Enum.drop_while(&(!in_koan?(&1, module)))
       |> List.first()
       |> extract_file_and_line

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -22,7 +22,7 @@ defmodule Koans do
           unquote(compiled_body)
           :ok
         rescue
-          e -> {:error, __STACKTRACE__, e}
+          e -> {:error, e, {:location, __ENV__.file, __ENV__.line}}
         end
       end
     end
@@ -39,7 +39,7 @@ defmodule Koans do
           unquote(single_var)
           :ok
         rescue
-          e -> {:error, __STACKTRACE__, e}
+          e -> {:error, e, {:location, __ENV__.file, __ENV__.line}}
         end
       end
     end
@@ -57,7 +57,7 @@ defmodule Koans do
           unquote(multi_var)
           :ok
         rescue
-          e -> {:error, __STACKTRACE__, e}
+          e -> {:error, e, {:location, __ENV__.file, __ENV__.line}}
         end
       end
     end
@@ -98,8 +98,8 @@ defmodule Koans do
     end
   end
 
-  defp koans(env) do
-    env.module
+  defp koans(%{module: module}) do
+    module
     |> Module.get_attribute(:koans)
     |> Enum.reverse()
   end

--- a/test/display/failure_test.exs
+++ b/test/display/failure_test.exs
@@ -39,11 +39,29 @@ defmodule FailureTests do
 
   test "only offending lines are displayed for errors" do
     [koan] = SingleArity.all_koans()
-    error = apply(SingleArity, koan, []) |> Tuple.to_list |> List.last |> error
+    error = apply(SingleArity, koan, []) |> error()
 
     assert Failure.format_failure(error) == """
-           Assertion failed in some_file.ex:42\nmatch?(:foo, ___)
+           Assertion failed in some_file.ex:42
+           match?(:foo, ___)
            """
+  end
+
+  test "formats errors such as arity mismatches as such" do
+    e = error({:error, %FunctionClauseError{args: nil, arity: 1, clauses: nil, function: :chardata_to_string, kind: nil, module: IO}, nil})
+
+    assert Failure.format_failure(e) == """
+           Error in some_file.ex:42
+           ** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1
+           """
+  end
+
+  defp error({:error, error, _}) do
+    %{
+      error: error,
+      file: "some_file.ex",
+      line: 42
+    }
   end
 
   defp error(error) do

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -7,7 +7,7 @@ defmodule ExecuteTest do
 
   test "stops at the first failing koan" do
     {:failed, %{file: file, line: line}, SampleKoan, _name} = Execute.run_module(SampleKoan)
-    assert file == 'test/support/sample_koan.ex'
+    assert file == "test/support/sample_koan.ex"
     assert line == 8
   end
 


### PR DESCRIPTION
Using __STACKTRACE__ is not really an option due to it requiring a
try/catch block, which we'd have to possibly add to every koan.

Side-step the issue by calling into Erlang