### PR TITLE
Change usage of System.stacktrace into __STACKTRACE__ and make tests pass

### DIFF
--- a/lib/execute.ex
+++ b/lib/execute.ex
@@ -38,14 +38,14 @@ defmodule Execute do
 
   defp expand(:ok, _), do: :ok
 
-  defp expand(error, module) do
+  defp expand({:error, stacktrace, exception}, module) do
     {file, line} =
-      System.stacktrace()
+      stacktrace
       |> Enum.drop_while(&(!in_koan?(&1, module)))
       |> List.first()
       |> extract_file_and_line
 
-    %{error: error, file: file, line: line}
+    %{error: exception, file: file, line: line}
   end
 
   defp in_koan?({module, _, _, _}, koan), do: module == koan

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -22,7 +22,7 @@ defmodule Koans do
           unquote(compiled_body)
           :ok
         rescue
-          e -> e
+          e -> {:error, __STACKTRACE__, e}
         end
       end
     end
@@ -39,7 +39,7 @@ defmodule Koans do
           unquote(single_var)
           :ok
         rescue
-          e -> e
+          e -> {:error, __STACKTRACE__, e}
         end
       end
     end
@@ -57,7 +57,7 @@ defmodule Koans do
           unquote(multi_var)
           :ok
         rescue
-          e -> e
+          e -> {:error, __STACKTRACE__, e}
         end
       end
     end

--- a/test/display/failure_test.exs
+++ b/test/display/failure_test.exs
@@ -39,7 +39,7 @@ defmodule FailureTests do
 
   test "only offending lines are displayed for errors" do
     [koan] = SingleArity.all_koans()
-    error = apply(SingleArity, koan, []) |> error()
+    error = apply(SingleArity, koan, []) |> Tuple.to_list |> List.last |> error
 
     assert Failure.format_failure(error) == """
            Assertion failed in some_file.ex:42\nmatch?(:foo, ___)

--- a/test/koans/comprehensions_koans_test.exs
+++ b/test/koans/comprehensions_koans_test.exs
@@ -9,7 +9,7 @@ defmodule ComprehensionsTests do
       ["Hello World", "Apple Pie"],
       ["little dogs", "little cats", "big dogs", "big cats"],
       [4, 5, 6],
-      ["Apple Pie", "Pecan Pie", "Pumpkin Pie"],
+      %{"Pecan" => "Pecan Pie", "Pumpkin" => "Pumpkin Pie"}
     ]
 
     test_all(Comprehensions, answers)


### PR DESCRIPTION
**Changes in getting a stacktrace from a failed koan**
As of Elixir 1.10, the usage of `System.stacktrace` to retrieve a stacktrace is now deprecated and is also non functional. Refer to the [docs](https://hexdocs.pm/elixir/System.html#stacktrace/0).

#242 tried substituting `System.stacktrace` with Erlang's `:erlang.get_stacktrace()` but it returns an empty list instead.

So, I substituted the calling of `System.stacktrace` in a non rescue context when trying to report errors with a call to `__STACKTRACE__` in the Koan macro itself, for normal execution and for tests, something that #242 suggested.

**Making the tests pass**
Even then, the tests would not pass. Two tests were failing.
The failure_test.exs was providing input arguments which were not correct for the output the tests asserted.
The comprehension_koans_test.exs was out of date with respect to the koan itself.

**Now the tests pass and a few koans I tried worked as well.**

[closes #250]
