### PR TITLE
Mismatch on koan description and assertion in 07_keyword_lists

### DIFF
--- a/lib/koans/07_keyword_lists.ex
+++ b/lib/koans/07_keyword_lists.ex
@@ -17,9 +17,8 @@ defmodule KeywordLists do
 
   koan "You could access the values of repeating key" do
     kw_list = [foo: "bar", foo1: "bar1", foo: "baz"]
-    values = Keyword.get_values(kw_list, :foo)
 
-    assert List.last(values) == ___
+    assert Keyword.get_values(kw_list, :foo) == [___, ___]
   end
 
   koan "Keyword lists are just special syntax for lists of two-element tuples" do

--- a/lib/koans/10_structs.ex
+++ b/lib/koans/10_structs.ex
@@ -43,12 +43,12 @@ defmodule Structs do
   end
 
   koan "Use the put_in macro to replace a nested value" do
-    airline = %Airline{plane: %Plane{maker: :boeing}}
+    airline = %Airline{}
     assert put_in(airline.plane.maker, :airbus) == ___
   end
 
   koan "Use the update_in macro to modify a nested value" do
-    airline = %Airline{plane: %Plane{maker: :boeing, passengers: 200}}
+    airline = %Airline{plane: %Plane{passengers: 200}}
     assert update_in(airline.plane.passengers, fn x -> x + 2 end) == ___
   end
 

--- a/test/koans/keyword_lists_koans_test.exs
+++ b/test/koans/keyword_lists_koans_test.exs
@@ -6,7 +6,7 @@ defmodule KeywordListsTests do
     answers = [
       "bar",
       "bar",
-      "baz",
+      {:multiple, ["bar", "baz"]},
       {:multiple, [:foo, "bar"]},
       "foo"
     ]


### PR DESCRIPTION
Koan description refers to the values of the key in a keyword list, so it should be asserting for a list of values.  

Also remove some duplication of struct defaults, %Plane already has `maker: boeing` default.