### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/koans/03_numbers.ex
+++ b/lib/koans/03_numbers.ex
@@ -123,8 +123,11 @@ defmodule Numbers do
     assert 0 in range == ___
   end
 
+  def is_range?(%Range{}), do: true
+  def is_range?(_), do: false
+
   koan "Is this a range?" do
-    assert Range.range?(1..10) == ___
-    assert Range.range?(0) == ___
+    assert is_range?(1..10) == ___
+    assert is_range?(0) == ___
   end
 end

--- a/lib/meditate.ex
+++ b/lib/meditate.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Meditate do
     Application.ensure_all_started(:elixir_koans)
     Code.compiler_options(ignore_module_conflict: true)
 
-    {parsed, _, _} = OptionParser.parse(args)
+    {parsed, _, _} = OptionParser.parse(args, switches: [])
 
     modules =
       parsed


### PR DESCRIPTION
Shows up when running mix meditate:
`warning: not passing the :switches or :strict option to OptionParser is deprecated`

Shows up when running mix test:
`warning: Range.range?/1 is deprecated. Pattern match on first..last instead`
