### PR TITLE
use atom booleans in atom koan & use keyword list in keyword list koan

### DIFF
--- a/lib/koans/04_atoms.ex
+++ b/lib/koans/04_atoms.ex
@@ -11,8 +11,8 @@ defmodule Atoms do
   koan "It is surprising to find out that booleans are atoms" do
     assert is_atom(true) == ___
     assert is_boolean(false) == ___
-    assert true == ___
-    assert false == ___
+    assert :true === ___
+    assert :false === ___
   end
 
   koan "Like booleans, the nil value is also an atom" do

--- a/lib/koans/07_keyword_lists.ex
+++ b/lib/koans/07_keyword_lists.ex
@@ -26,8 +26,8 @@ defmodule KeywordLists do
   end
 
   koan "But unlike maps, the keys in keyword lists must be atoms" do
-    not_kw_list = [{"foo", "bar"}]
+    kw_list = [foo: "bar"]
 
-    assert_raise ArgumentError, fn -> not_kw_list[___] end
+    assert_raise ArgumentError, fn -> kw_list[___] end
   end
 end


### PR DESCRIPTION
Atom koan is trying to demonstrate that booleans are actually atoms.  Writing it as `:true` and `:false` in the assertion upfront would make it more obvious, because the learner would likely be expecting to enter `true` and `false` in the blank area.  Solves #226.

Also Keyword List koan had a "non keyword list" for no reason, changing it to a keyword list keeps to the spirit of the koan and reduces confusion.  Solves #222 