### PR TITLE
Remove Enum.fetch usage for MapSet

### DIFF
--- a/lib/koans/09_map_sets.ex
+++ b/lib/koans/09_map_sets.ex
@@ -5,11 +5,7 @@ defmodule MapSets do
 
   @set MapSet.new([1, 2, 3, 4, 5])
 
-  koan "I am very similar to a list" do
-    assert Enum.fetch(@set, 0) == {:ok, ___}
-  end
-
-  koan "However, I do not allow duplication" do
+  koan "I do not allow duplication" do
     new_set = MapSet.new([1, 1, 2, 3, 3, 3])
 
     assert MapSet.size(new_set) == ___


### PR DESCRIPTION
`Enum.fetch(@set, 0)` usage should be discouraged as it only works for MapSet created with list size < 32.

So I think that koan should be removed.