### PR TITLE
Update file_system

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,3 @@
-%{"file_system": {:hex, :file_system, "0.2.2", "7f1e9de4746f4eb8a4ca8f2fbab582d84a4e40fa394cce7bfcb068b988625b06", [], [], "hexpm"}}
+%{
+  "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
+}


### PR DESCRIPTION
Current locked version of `file_system` doesn't work for me on a fresh clone using macOS 11.2.3.

```
MacOSX 10.7 or later required for --file-events
```

This change is the result of running `mix deps.update file_system` and allows `mix meditate` to work as expected.