### PR TITLE
be stricter about which files to watch

### DIFF
--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -23,6 +23,7 @@ defmodule Runner do
   end
 
   @koan_path_pattern ~r/lib\/koans\/(\d+)_\w+.ex$/
+  def koan_path_pattern, do: @koan_path_pattern
 
   def path_to_number(path) do
     [_path, number] = Regex.run(@koan_path_pattern, path)

--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -21,7 +21,7 @@ defmodule Watcher do
   end
 
   defp reload(file) do
-    if Path.extname(file) == ".ex" do
+    if String.match?(file, Runner.koan_path_pattern()) do
       try do
         file
         |> portable_load_file


### PR DESCRIPTION
Things like flycheck-elixir in Emacs can create temporary files in the
same directory as the upstream files that contain the koans, with a
"flycheck_" prefix but still ending in ".ex". This change makes it so
that we skip such files.