### PR TITLE
Add helpful message when processes koan assertion fails

### DIFF
--- a/lib/koans/15_processes.ex
+++ b/lib/koans/15_processes.ex
@@ -77,7 +77,10 @@ defmodule Processes do
     pid = spawn(greeter)
 
     send(pid, {:hello, self()})
-    assert_receive ___
+
+    timeout = 100 # ms
+    failure_message = "Sorry, I didn't get the right message. Look at the message that is sent back very closely, and try again"
+    assert_receive ___, timeout, failure_message
   end
 
   def yelling_echo_loop do


### PR DESCRIPTION
[closes #266]

# Problem
Failure was confusing in #266.

# Solution
Add message to nudge learner in the right direction.

```
Processes

Now meditate upon Processes
|                              | 0 of 36
----------------------------------------
A common pattern is to include the sender in the message, so that it can reply
Assertion failed in lib/koans/15_processes.ex:83
Sorry, I didn't get the right message. Look at the message that is sent back very closely, and try again
```