### PR TITLE
Fix example to actually check message order as desc suggests

### DIFF
--- a/lib/koans/15_processes.ex
+++ b/lib/koans/15_processes.ex
@@ -63,8 +63,18 @@ defmodule Processes do
     send(self(), "hola!")
     send(self(), "como se llama?")
 
-    assert_receive ___
-    assert_receive ___
+    first_message =
+      receive do
+        message -> message
+      end
+
+    second_message =
+      receive do
+        message -> message
+      end
+
+    assert first_message == ___
+    assert second_message == ___
   end
 
   koan "A common pattern is to include the sender in the message, so that it can reply" do


### PR DESCRIPTION
Reported in #275

# Problem
Example suggests order is important, but fails to check that in how it is written.

# Solution
Refactor example to explicitly receive messages and assert the order in which they are received.