### PR TITLE
fix(config): replace deprecated Mix.Config by Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :ex_unit, assert_receive_timeout: 100


### PR DESCRIPTION
```sh
➜  elixir-koans git:(master) mix deps.get
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:1
```

Mix.Config is deprecated (see [here](https://hexdocs.pm/elixir/1.14.3/Config.html#module-migrating-from-use-mix-config))