### PR TITLE
fix(ci): pin ubuntu-20 to run github actions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fixing the issue pointed out in [this GitHub workflow execution](https://github.com/elixirkoans/elixir-koans/actions/runs/4314335021/jobs/7527274281)

We would be able to use ubuntu-22.04 when upgrading the OTP version to, at least, 24.2 (see [here](https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp))