### PR TITLE
The worker/2 function from the Supervisor.Spec module is deprecated

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
       with:
-        elixir-version: '1.12.3' # Define the elixir version [required]
+        elixir-version: '1.5' # Define the elixir version [required]
         otp-version: '24.1' # Define the OTP version [required]
     - name: Restore dependencies cache
       uses: actions/cache@v2

--- a/lib/elixir_koans.ex
+++ b/lib/elixir_koans.ex
@@ -3,13 +3,11 @@ defmodule ElixirKoans do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
-      worker(Display, []),
-      worker(Tracker, []),
-      worker(Runner, []),
-      worker(Watcher, [])
+      {Display, []},
+      {Tracker, []},
+      {Runner, []},
+      {Watcher, []}
     ]
 
     opts = [strategy: :one_for_one, name: ElixirKoans.Supervisor]


### PR DESCRIPTION
Instead of using Supervisor.Spec.worker/2, you should define your child processes within the Supervisor module using the child_spec/1 function.