### PR TITLE
Fix inconsistent printing of meditation

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,6 +1,7 @@
 name: Elixir CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/lib/display.ex
+++ b/lib/display.ex
@@ -56,11 +56,13 @@ defmodule Display do
   end
 
   defp format(failure, module, name) do
+    progress_bar = ProgressBar.progress_bar(Tracker.summarize())
+    progress_bar_underline = String.duplicate("-", String.length(progress_bar))
     """
     #{Intro.intro(module, Tracker.visited())}
     Now meditate upon #{format_module(module)}
-    #{ProgressBar.progress_bar(Tracker.summarize())}
-    ----------------------------------------
+    #{progress_bar}
+    #{progress_bar_underline}
     #{name}
     #{Failure.format_failure(failure)}
     """

--- a/lib/display.ex
+++ b/lib/display.ex
@@ -21,15 +21,14 @@ defmodule Display do
     {:noreply, %{state | clear_screen: false}}
   end
 
-  def handle_cast(:clear_screen, %{clear_screen: true} = state) do
-    IO.puts(ANSI.clear())
-    IO.puts(ANSI.home())
+  def handle_call(:clear_screen, _from, %{clear_screen: true} = state) do
+    ANSI.clear <> ANSI.home |> IO.puts()
 
-    {:noreply, state}
+    {:reply, :ok, state}
   end
 
-  def handle_cast(:clear_screen, state) do
-    {:noreply, state}
+  def handle_call(:clear_screen, _from, state) do
+    {:reply, :ok, state}
   end
 
   def invalid_koan(koan, modules) do
@@ -53,7 +52,7 @@ defmodule Display do
   end
 
   def clear_screen do
-    GenServer.cast(__MODULE__, :clear_screen)
+    GenServer.call(__MODULE__, :clear_screen)
   end
 
   defp format(failure, module, name) do

--- a/lib/display/progress_bar.ex
+++ b/lib/display/progress_bar.ex
@@ -4,12 +4,17 @@ defmodule Display.ProgressBar do
 
   def progress_bar(%{current: current, total: total}) do
     arrow = calculate_progress(current, total) |> build_arrow
+    progress_percentage = calculate_percentage(current, total)
 
-    "|" <> String.pad_trailing(arrow, @progress_bar_length) <> "| #{current} of #{total}"
+    "|" <> String.pad_trailing(arrow, @progress_bar_length) <> "| #{current} of #{total} -> #{progress_percentage}% complete"
   end
 
   defp calculate_progress(current, total) do
     round(current / total * @progress_bar_length)
+  end
+
+  defp calculate_percentage(current, total) do
+    Float.round(current / total * 100, 1)
   end
 
   defp build_arrow(0), do: ""

--- a/test/display/progress_bar_test.exs
+++ b/test/display/progress_bar_test.exs
@@ -5,16 +5,16 @@ defmodule ProgressBarTest do
 
   test "empty bar" do
     bar = ProgressBar.progress_bar(%{total: 12, current: 0})
-    assert bar == "|                              | 0 of 12"
+    assert bar == "|                              | 0 of 12 -> 0.0% complete"
   end
 
   test "puts counter on the right until half the koans are complete" do
     bar = ProgressBar.progress_bar(%{total: 12, current: 3})
-    assert bar == "|=======>                      | 3 of 12"
+    assert bar == "|=======>                      | 3 of 12 -> 25.0% complete"
   end
 
   test "full bar" do
     bar = ProgressBar.progress_bar(%{total: 12, current: 12})
-    assert bar == "|=============================>| 12 of 12"
+    assert bar == "|=============================>| 12 of 12 -> 100.0% complete"
   end
 end


### PR DESCRIPTION
This fixes the issues I observed while solving the koans. Some of the issues I noticed are:
- Random vertical position of printing koans
- Sometimes koan intro printed before clear screen
- Next koan does not appear when all koan passes for a module