### PR TITLE
Fix test warnings on Elixir 1.17

### DIFF
--- a/lib/display/intro.ex
+++ b/lib/display/intro.ex
@@ -6,7 +6,7 @@ defmodule Display.Intro do
     if module in modules do
       ""
     else
-      show_intro(module.intro)
+      show_intro(module.intro())
     end
   end
 

--- a/lib/execute.ex
+++ b/lib/execute.ex
@@ -1,7 +1,7 @@
 defmodule Execute do
   @moduledoc false
   def run_module(module, callback \\ fn _result, _module, _koan -> nil end) do
-    Enum.reduce_while(module.all_koans, :passed, fn koan, _ ->
+    Enum.reduce_while(module.all_koans(), :passed, fn koan, _ ->
       module
       |> run_koan(koan)
       |> hook(module, koan, callback)

--- a/lib/tracker.ex
+++ b/lib/tracker.ex
@@ -18,7 +18,7 @@ defmodule Tracker do
   def set_total(modules) do
     total =
       modules
-      |> Enum.flat_map(& &1.all_koans)
+      |> Enum.flat_map(& &1.all_koans())
       |> Enum.count()
 
     Agent.update(__MODULE__, fn _ -> %Tracker{total: total} end)

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -7,7 +7,7 @@ defmodule ExecuteTest do
 
   test "stops at the first failing koan" do
     {:failed, %{file: file, line: line}, SampleKoan, _name} = Execute.run_module(SampleKoan)
-    assert file == 'test/support/sample_koan.ex'
+    assert file == ~c"test/support/sample_koan.ex"
     assert line == 9
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,7 +6,7 @@ defmodule TestHarness do
   import ExUnit.Assertions
 
   def test_all(module, answers) do
-    module.all_koans
+    module.all_koans()
     |> check_answer_count(answers, module)
     |> Enum.zip(answers)
     |> run_all(module)


### PR DESCRIPTION
On Elixir 1.17 warnings like these will be generated by `mix test`:
```
warning: using map.field notation (without parentheses) to invoke function SampleKoan.all_koans() is deprecated, you must add parentheses instead: remote.function()
```