### PR TITLE
fix(docker): bump elixir image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.5
+FROM elixir:1.18.4
 RUN apt-get update && apt-get install -y inotify-tools
 WORKDIR /elixir-koans
 ADD . /elixir-koans/


### PR DESCRIPTION
Hey there!

I bumped into an issue when building the current Dockerfile. A 404 error happens when fetching the stretch release from the Debian repo:

![image](https://github.com/user-attachments/assets/68d2578f-1d98-4bb3-b4b1-ab3f65d41c41)

This is happening because the base Docker image depends on the stretch release living on the [regular Debian repo](https://ftp.debian.org/debian/dists/), which has now been moved to the [archived one](https://archive.debian.org/debian/dists/). Bumping the image version fix this issue.

Also, I'd just like to say I really loved the work done on introducing Elixir to newcomers in this repo. Awesome stuff! ❤️