### PR TITLE
chore: add credo fixes

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,216 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: %{
+        enabled: [
+          #
+          ## Consistency Checks
+          #
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
+
+          #
+          ## Design Checks
+          #
+          # You can customize the priority of any check
+          # Priority values are: `low, normal, high, higher`
+          #
+          {Credo.Check.Design.AliasUsage,
+           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          {Credo.Check.Design.TagFIXME, []},
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          #
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithSingleClause, []},
+
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.Apply, []},
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.FilterCount, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.Dbg, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.UnsafeExec, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.WrongTestFileExtension, []}
+        ],
+        disabled: [
+          #
+          # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #   and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
+          {Credo.Check.Readability.OnePipePerLine, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PassAsyncInTestCases, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+
+          # {Credo.Check.Refactor.MapInto, []},
+
+          #
+          # Custom checks can be created using `mix credo.gen.check`.
+          #
+        ]
+      }
+    }
+  ]
+}

--- a/lib/blanks.ex
+++ b/lib/blanks.ex
@@ -1,5 +1,4 @@
 defmodule Blanks do
-  @moduledoc false
   def replace(ast, replacements) do
     replacements = List.wrap(replacements)
 

--- a/lib/display.ex
+++ b/lib/display.ex
@@ -1,5 +1,4 @@
 defmodule Display do
-  @moduledoc false
   use GenServer
 
   alias IO.ANSI

--- a/lib/display/colours.ex
+++ b/lib/display/colours.ex
@@ -1,5 +1,4 @@
 defmodule Display.Paint do
-  @moduledoc false
   def red(str), do: painter().red(str)
   def cyan(str), do: painter().cyan(str)
   def green(str), do: painter().green(str)
@@ -14,7 +13,6 @@ defmodule Display.Paint do
 end
 
 defmodule Display.Colours do
-  @moduledoc false
   alias IO.ANSI
 
   def red(str), do: colourize(ANSI.red(), str)
@@ -28,7 +26,6 @@ defmodule Display.Colours do
 end
 
 defmodule Display.Uncoloured do
-  @moduledoc false
   def red(str), do: str
   def cyan(str), do: str
   def green(str), do: str

--- a/lib/display/failure.ex
+++ b/lib/display/failure.ex
@@ -1,5 +1,4 @@
 defmodule Display.Failure do
-  @moduledoc false
   alias Display.Paint
 
   @no_value :ex_unit_no_meaningful_value

--- a/lib/display/intro.ex
+++ b/lib/display/intro.ex
@@ -1,5 +1,4 @@
 defmodule Display.Intro do
-  @moduledoc false
   alias Display.Paint
 
   def intro(module, modules) do

--- a/lib/display/notification.ex
+++ b/lib/display/notification.ex
@@ -1,5 +1,4 @@
 defmodule Display.Notifications do
-  @moduledoc false
   alias Display.Paint
 
   def congratulate do

--- a/lib/display/progress_bar.ex
+++ b/lib/display/progress_bar.ex
@@ -1,5 +1,4 @@
 defmodule Display.ProgressBar do
-  @moduledoc false
   @progress_bar_length 30
 
   def progress_bar(%{current: current, total: total}) do

--- a/lib/elixir_koans.ex
+++ b/lib/elixir_koans.ex
@@ -1,5 +1,4 @@
 defmodule ElixirKoans do
-  @moduledoc false
   use Application
 
   def start(_type, _args) do

--- a/lib/execute.ex
+++ b/lib/execute.ex
@@ -1,5 +1,4 @@
 defmodule Execute do
-  @moduledoc false
   def run_module(module, callback \\ fn _result, _module, _koan -> nil end) do
     Enum.reduce_while(module.all_koans, :passed, fn koan, _ ->
       module

--- a/lib/koans.ex
+++ b/lib/koans.ex
@@ -1,5 +1,4 @@
 defmodule Koans do
-  @moduledoc false
   defp valid_name(name) do
     Regex.match?(~r/([A-Z]|\.\.\.).+/, name)
   end

--- a/lib/koans/01_equalities.ex
+++ b/lib/koans/01_equalities.ex
@@ -1,5 +1,4 @@
 defmodule Equalities do
-  @moduledoc false
   use Koans
 
   @intro """

--- a/lib/koans/02_strings.ex
+++ b/lib/koans/02_strings.ex
@@ -1,5 +1,4 @@
 defmodule Strings do
-  @moduledoc false
   use Koans
 
   @intro "Strings"

--- a/lib/koans/03_numbers.ex
+++ b/lib/koans/03_numbers.ex
@@ -1,5 +1,4 @@
 defmodule Numbers do
-  @moduledoc false
   require Integer
   use Koans
 

--- a/lib/koans/03_numbers.ex
+++ b/lib/koans/03_numbers.ex
@@ -123,11 +123,11 @@ defmodule Numbers do
     assert 0 in range == ___
   end
 
-  def is_range?(%Range{}), do: true
-  def is_range?(_), do: false
+  def range?(%Range{}), do: true
+  def range?(_), do: false
 
   koan "Is this a range?" do
-    assert is_range?(1..10) == ___
-    assert is_range?(0) == ___
+    assert range?(1..10) == ___
+    assert range?(0) == ___
   end
 end

--- a/lib/koans/04_atoms.ex
+++ b/lib/koans/04_atoms.ex
@@ -1,5 +1,4 @@
 defmodule Atoms do
-  @moduledoc false
   use Koans
 
   @intro "Atoms"

--- a/lib/koans/05_tuples.ex
+++ b/lib/koans/05_tuples.ex
@@ -1,5 +1,4 @@
 defmodule Tuples do
-  @moduledoc false
   use Koans
 
   @intro "Tuples"

--- a/lib/koans/06_lists.ex
+++ b/lib/koans/06_lists.ex
@@ -1,5 +1,4 @@
 defmodule Lists do
-  @moduledoc false
   use Koans
 
   @intro "Lists"

--- a/lib/koans/07_keyword_lists.ex
+++ b/lib/koans/07_keyword_lists.ex
@@ -1,5 +1,4 @@
 defmodule KeywordLists do
-  @moduledoc false
   use Koans
 
   @intro "KeywordLists"

--- a/lib/koans/08_maps.ex
+++ b/lib/koans/08_maps.ex
@@ -1,5 +1,4 @@
 defmodule Maps do
-  @moduledoc false
   use Koans
 
   @intro "Maps"

--- a/lib/koans/09_map_sets.ex
+++ b/lib/koans/09_map_sets.ex
@@ -1,5 +1,4 @@
 defmodule MapSets do
-  @moduledoc false
   use Koans
 
   @intro "My name is Set, MapSet."

--- a/lib/koans/10_structs.ex
+++ b/lib/koans/10_structs.ex
@@ -1,11 +1,9 @@
 defmodule Structs do
-  @moduledoc false
   use Koans
 
   @intro "Structs"
 
   defmodule Person do
-    @moduledoc false
     defstruct [:name, :age]
   end
 
@@ -37,12 +35,10 @@ defmodule Structs do
   end
 
   defmodule Plane do
-    @moduledoc false
     defstruct passengers: 0, maker: :boeing
   end
 
   defmodule Airline do
-    @moduledoc false
     defstruct plane: %Plane{}, name: "Southwest"
   end
 

--- a/lib/koans/11_sigils.ex
+++ b/lib/koans/11_sigils.ex
@@ -1,5 +1,4 @@
 defmodule Sigils do
-  @moduledoc false
   use Koans
 
   @intro "Sigils"

--- a/lib/koans/12_pattern_matching.ex
+++ b/lib/koans/12_pattern_matching.ex
@@ -1,5 +1,4 @@
 defmodule PatternMatching do
-  @moduledoc false
   use Koans
 
   @intro "PatternMatching"
@@ -95,7 +94,6 @@ defmodule PatternMatching do
   end
 
   defmodule Animal do
-    @moduledoc false
     defstruct [:kind, :name]
   end
 
@@ -105,7 +103,6 @@ defmodule PatternMatching do
   end
 
   defmodule Plane do
-    @moduledoc false
     defstruct passengers: 0, maker: :boeing
   end
 

--- a/lib/koans/13_functions.ex
+++ b/lib/koans/13_functions.ex
@@ -1,5 +1,4 @@
 defmodule Functions do
-  @moduledoc false
   use Koans
 
   @intro "Functions"

--- a/lib/koans/14_enums.ex
+++ b/lib/koans/14_enums.ex
@@ -1,5 +1,4 @@
 defmodule Enums do
-  @moduledoc false
   use Koans
 
   @intro "Enums"

--- a/lib/koans/15_processes.ex
+++ b/lib/koans/15_processes.ex
@@ -1,5 +1,4 @@
 defmodule Processes do
-  @moduledoc false
   use Koans
 
   @intro "Processes"

--- a/lib/koans/16_tasks.ex
+++ b/lib/koans/16_tasks.ex
@@ -1,5 +1,4 @@
 defmodule Tasks do
-  @moduledoc false
   use Koans
 
   @intro "Tasks"

--- a/lib/koans/17_agents.ex
+++ b/lib/koans/17_agents.ex
@@ -1,5 +1,4 @@
 defmodule Agents do
-  @moduledoc false
   use Koans
 
   @intro "Agents"

--- a/lib/koans/18_genservers.ex
+++ b/lib/koans/18_genservers.ex
@@ -1,11 +1,9 @@
 defmodule GenServers do
-  @moduledoc false
   use Koans
 
   @intro "GenServers"
 
   defmodule Laptop do
-    @moduledoc false
     use GenServer
 
     #####

--- a/lib/koans/19_protocols.ex
+++ b/lib/koans/19_protocols.ex
@@ -1,5 +1,4 @@
 defmodule Protocols do
-  @moduledoc false
   use Koans
 
   @intro "Want to follow the rules? Adhere to the protocol!"
@@ -13,23 +12,19 @@ defmodule Protocols do
   end
 
   defmodule Painter do
-    @moduledoc false
     @derive Artist
     defstruct name: ""
   end
 
   defmodule Musician do
-    @moduledoc false
     defstruct(name: "", instrument: "")
   end
 
   defmodule Dancer do
-    @moduledoc false
     defstruct(name: "", dance_style: "")
   end
 
   defmodule Physicist do
-    @moduledoc false
     defstruct(name: "")
   end
 

--- a/lib/koans/20_comprehensions.ex
+++ b/lib/koans/20_comprehensions.ex
@@ -1,5 +1,4 @@
 defmodule Comprehensions do
-  @moduledoc false
   use Koans
 
   @intro "A comprehension is made of three parts: generators, filters, and collectibles. We will look at how these interact with each other"

--- a/lib/meditate.ex
+++ b/lib/meditate.ex
@@ -1,5 +1,4 @@
 defmodule Mix.Tasks.Meditate do
-  @moduledoc false
   use Mix.Task
 
   @shortdoc "Start the koans"

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -1,5 +1,4 @@
 defmodule Runner do
-  @moduledoc false
   use GenServer
 
   def koan?(koan) do

--- a/lib/tracker.ex
+++ b/lib/tracker.ex
@@ -1,5 +1,4 @@
 defmodule Tracker do
-  @moduledoc false
   alias __MODULE__
 
   defstruct total: 0,

--- a/lib/watcher.ex
+++ b/lib/watcher.ex
@@ -1,5 +1,4 @@
 defmodule Watcher do
-  @moduledoc false
   use GenServer
 
   def start_link do

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Koans.Mixfile do
 
   defp deps do
     [{:file_system, "~> 0.2"},
-    {:credo, "~> 1.7", only: [:dev, :test], runtime: false}]
+    {:credo, "~> 1.7.7", only: [:dev, :test], runtime: false}]
   end
 
   defp elixirc_path(:test), do: ["lib/", "test/support"]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
-  "credo": {:hex, :credo, "1.7.1", "6e26bbcc9e22eefbff7e43188e69924e78818e2fe6282487d0703652bc20fd62", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "e9871c6095a4c0381c89b6aa98bc6260a8ba6addccf7f6a53da8849c748a58a2"},
+  "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
+  "credo": {:hex, :credo, "1.7.12", "9e3c20463de4b5f3f23721527fcaf16722ec815e70ff6c60b86412c695d426c1", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8493d45c656c5427d9c729235b99d498bd133421f3e0a683e5c1b561471291e5"},
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
-  "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
+  "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
 }

--- a/test/executor_test.exs
+++ b/test/executor_test.exs
@@ -8,7 +8,7 @@ defmodule ExecuteTest do
   test "stops at the first failing koan" do
     {:failed, %{file: file, line: line}, SampleKoan, _name} = Execute.run_module(SampleKoan)
     assert file == 'test/support/sample_koan.ex'
-    assert line == 9
+    assert line == 8
   end
 
   test "can access intro" do

--- a/test/support/passing_koan.ex
+++ b/test/support/passing_koan.ex
@@ -1,5 +1,4 @@
 defmodule PassingKoan do
-  @moduledoc false
   use Koans
 
   @intro "something"

--- a/test/support/sample_koan.ex
+++ b/test/support/sample_koan.ex
@@ -1,5 +1,4 @@
 defmodule SampleKoan do
-  @moduledoc false
   use Koans
 
   @intro """

--- a/test/support/single_arity_koan.ex
+++ b/test/support/single_arity_koan.ex
@@ -1,5 +1,4 @@
 defmodule SingleArity do
-  @moduledoc false
   use Koans
 
   @intro """


### PR DESCRIPTION
Hey there!

Introducing a few Credo-related changes:

- [bump Credo version to 1.7.7](https://github.com/elixirkoans/elixir-koans/commit/4ea7663fca88f919d9f0d58f35e8c8d26f47bc18)
  - when running Credo with Elixir 1.18, [a `CaseClauseError` was being raised](https://github.com/user-attachments/assets/815e144a-f2d5-4aa0-8c1c-b607a50d2cc1). This issue was [tracked and fixed on Credo's repo](https://github.com/rrrene/credo/issues/1139), and seems to happen as of Elixir version 1.17. The fix was released on [Credo version 1.7.7](https://github.com/rrrene/credo/releases/tag/v1.7.7).
-  [Add Credo config file, disabling the `Readability.ModuleDoc` check](https://github.com/elixirkoans/elixir-koans/commit/dc5588dc0a4a894146f2ad931d66f483772ced68)
    - since every module has a `@moduledoc false` doc, there is no point in having this enforced style check, right?
- [remove false @moduledocs and update hardcoded line reference in test](https://github.com/elixirkoans/elixir-koans/commit/a5235acd6dca95fe8f5b651f1dc6260dccf07ac7)
  - one of the tests has a hard coded line reference which decreased by 1 after removing one of the `@moduledoc false` lines.
- [fix Readability.PredicateFunctionNames credo check violation](https://github.com/elixirkoans/elixir-koans/commit/cc7ed7a9fa3e0ae620d7474b86fd3bf586aeddfd)
  - change `is_range?` function name to `range?`, following the [Readability.PredicateFunctionNames](https://hexdocs.pm/credo/Credo.Check.Readability.PredicateFunctionNames.html) style for predicate functions.