### PR TITLE
Fix Elixir Version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.5
+FROM elixir:1.15
 RUN apt-get update && apt-get install -y inotify-tools
 WORKDIR /elixir-koans
 ADD . /elixir-koans/


### PR DESCRIPTION
It appears that on dockerhub there is no such version as 1.5