### PR TITLE
Address Compilation Warning

### DIFF
--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -13,7 +13,7 @@ defmodule Runner do
     {:ok, modules} = :application.get_key(:elixir_koans, :modules)
 
     modules
-    |> Stream.map(&(&1.module_info |> get_in([:compile, :source])))
+    |> Stream.map(&(&1.module_info() |> get_in([:compile, :source])))
     # Paths are charlists
     |> Stream.map(&to_string/1)
     |> Stream.zip(modules)


### PR DESCRIPTION
Add `()` to call to `Agents.module_info/0` to remove a compilation warning. (Elixir 1.18.4)

```
warning: using map.field notation (without parentheses) to invoke function Agents.module_info() is
deprecated, you must add parentheses instead: remote.function()
  (elixir_koans 0.0.1) lib/runner.ex:16: anonymous fn/1 in Runner.modules/0
  (elixir 1.18.4) lib/stream.ex:626: anonymous fn/4 in Stream.map/2
  (elixir 1.18.4) lib/enum.ex:4968: Enumerable.List.reduce/3
  (elixir 1.18.4) lib/stream.ex:1773: Enumerable.Stream.do_each/4
  (elixir 1.18.4) lib/stream/reducers.ex:100: Stream.Reducers.do_zip_next/6
```